### PR TITLE
Rename android lib artifact id

### DIFF
--- a/native-libs/android/gradle.properties
+++ b/native-libs/android/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 android.useAndroidX=true
 
-VERSION_NAME=0.1.6
+VERSION_NAME=0.1.7
 GROUP=com.walmartlabs.ern
 
 POM_NAME=LiveBundle


### PR DESCRIPTION
`live-bundle` => `livebundle`
Also published initial version `0.1.7` using this new artifact id.

Closes https://github.com/electrode-io/livebundle/issues/1