### PR TITLE
Validate configuration against json schema

### DIFF
--- a/packages/livebundle-cli/package.json
+++ b/packages/livebundle-cli/package.json
@@ -11,7 +11,8 @@
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo",
     "compile": "tsc -b tsconfig.build.json",
     "prepublishOnly": "yarn build",
-    "start": "node dist/cli.js"
+    "start": "node dist/cli.js",
+    "test": "mocha"
   },
   "dependencies": {
     "chalk": "^4.0.0",

--- a/packages/livebundle-cli/src/cli.ts
+++ b/packages/livebundle-cli/src/cli.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { program } from "commander";
 import debug from "debug";
 import fs from "fs-extra";
-import { TaskRunner } from "livebundle-sdk";
+import { TaskRunner, taskSchema } from "livebundle-sdk";
 import { loadConfig } from "livebundle-utils";
 import emoji from "node-emoji";
 import open from "open";
@@ -11,6 +11,7 @@ import ora from "ora";
 import path from "path";
 import qrcodepng from "qrcode";
 import qrcodeterm from "qrcode-terminal";
+import { configSchema } from "./schemas";
 import { Config } from "./types";
 
 const pJsonPath = path.resolve(__dirname, "..", "package.json");
@@ -27,10 +28,12 @@ program
   .action(async ({ config }: { config?: string }) => {
     const defaultConfigPath = path.resolve(__dirname, "../config/default.yaml");
 
-    const conf = loadConfig<Config>({
+    const conf = await loadConfig<Config>({
       configPath: config,
       defaultConfigPath,
       defaultFileName: "livebundle",
+      refSchemas: [taskSchema],
+      schema: configSchema,
     });
 
     dlog(`Configuration:\n${JSON.stringify(conf, null, 2)}`);

--- a/packages/livebundle-cli/src/index.ts
+++ b/packages/livebundle-cli/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./schemas";
 export * from "./types";

--- a/packages/livebundle-cli/src/schemas/config.json
+++ b/packages/livebundle-cli/src/schemas/config.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/cli-config.json",
+  "properties": {
+    "qrcode": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "object",
+          "properties": {
+            "generate": {
+              "type": "boolean"
+            },
+            "small": {
+              "type": "boolean"
+            }
+          }
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "generate": {
+              "type": "boolean"
+            },
+            "margin": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": { "$data": "1/width" }
+            },
+            "width": {
+              "type": "number",
+              "minimum": 100
+            },
+            "open": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "task": {
+      "$ref": "sdk-task.json"
+    }
+  }
+}

--- a/packages/livebundle-cli/src/schemas/index.ts
+++ b/packages/livebundle-cli/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import configSchema from "./config.json";
+export { configSchema };

--- a/packages/livebundle-cli/test/config.test.ts
+++ b/packages/livebundle-cli/test/config.test.ts
@@ -1,0 +1,18 @@
+import { doesNotReject } from "assert";
+import { taskSchema } from "livebundle-sdk";
+import { loadConfig } from "livebundle-utils";
+import "mocha";
+import path from "path";
+import { configSchema } from "../src/schemas";
+
+describe("config", () => {
+  it("should not fail loading default config", async () => {
+    await doesNotReject(
+      loadConfig({
+        configPath: path.resolve(__dirname, "../config/default.yaml"),
+        refSchemas: [taskSchema],
+        schema: configSchema,
+      }),
+    );
+  });
+});

--- a/packages/livebundle-cli/tsconfig.build.json
+++ b/packages/livebundle-cli/tsconfig.build.json
@@ -6,7 +6,7 @@
     "typeRoots": ["./typings"],
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./src/**/*.json"],
   "references": [
     {
       "path": "../livebundle-sdk/tsconfig.build.json"

--- a/packages/livebundle-github/config/sample.yaml
+++ b/packages/livebundle-github/config/sample.yaml
@@ -1,0 +1,70 @@
+# GitHub application configuration
+github:
+  appIdentifier: 65645
+  clientId: Iv1.04849b1cb72ad0fa
+  clientSecret: 14c640bb4946970807366672ba6bb077c7de7009
+  privateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEpAIBAAKCAQEA3ddwHEVpGM3OXYNY2jro2bDZWzzuNEzwRxl7pgqwG7eWXEGe
+    NDC+qwOuyclz/2qtqg83eJ9PvUnaG+vmwdbeu7dzkQuCtKFi4sFMCFbl6fZcbn0u
+    NTfK5dHjjdaQjEqD+WZsTxec8NzMrMWOeJ07sZ3TsmWjXm3AZVn27Mnk0nnY6WIC
+    6EwSI80pvDDkUHWrPE/WSHYVJWxsl6KpICAu73i2N2hplG13XEmP1TIMwoktSKB7
+    h+9au+S3KkCdxXzFyN9hVBUZu8FcvbO8ZPSmb5bGyVw44pFQU9X39iqWZtMpc8V4
+    A/qIwRYuf6mFcnvdwkpbuZkRJq06VFHeFsDe9wIDAQABAoIBAA+XWpvCDRbfMAfG
+    eXIs/bx+/2e4Ko2mcqSsl9Idoi7wgjLNsc69NklSovAvpmVnG/l9xEpH+BS3ogqg
+    U8F/1nue8xJYmsETLp39M9jKMrJ0zB4/0gWPfEUWsUWAtPwHKKtYlXghkrgi7Ieg
+    AtlbQ5zCGOTK2+aBFCqLXh1aOyjHofBubcX/qMVwKqoC+cHtcqQVa3aAZPyovrt5
+    M1zlUxWfhA/xqIT0PPSkgMrHZbScSBMMrbQ2JZ1EysySK2Mv43FQPGD5oNYZOyJx
+    F1q8ZDVXvPsqN/pN3gsQ3wCzRCVgtkIpD2sglND+yte9GwVc3EVLQXIO1dRNYt1A
+    ea2kBgECgYEA/63lxv6eRND8hIDnTFavdrfARJN9ZQhIPkFzRVS1GCxFKGUwBcCX
+    Qr1fZsbJ4bm/hnxbrVgRGXv0oTuDrGDjVFvdjCFpK4GP6ZB1nNnRmxLhTTla0uXj
+    1oh/9LUygPDYqjtxf9RyzzznxA7QumorWw+3wY8X/9Cw6lNIV+cQ04ECgYEA3h6s
+    sClnniGE8LLqO1RpzNTJbM5vUsrl9zCBfXeQ4lqRKutbmgoKWCSO7hJQjC/qoLip
+    sjyMc4a5R8RxlEb1yBA0+7PzFUJqS4LSpLjWZzHN6XMmBHihAbC31EHX6Wfsu8De
+    m81D66w4bdtzmIpEMTWLcmi84LIuKIHL4+MdjncCgYEA67xhNCWEtXxepqjXGap/
+    Ix2pmZDHN8T4HvZnpo/sXLpMlV8edN9KV42VDYSWklmZvhygxmWBdpa0SYg+8ktu
+    rlP5I/+WITfXAYlg91pZiPpSYsoz9GljtWSrXWtHgl0N137xOeQeavcD1d+3EXlc
+    Ohx2127guMuoopRhCjMQb4ECgYEAs81K5vMtYJErpxh9iXdkiZ26S6yz6uY5z6Zh
+    O+pcyw6bMo4AwandA8rcNJV4xHJJUL8LBzACVcY6F4FKm8fxT3jnGtVpMc1odCW7
+    VAIX9MMZNx+yJ65qTw75UAXYvKUWukl/Kcm4cH8h0rPxWAqc9uSsM/na41z5BmtD
+    W/7OPzMCgYBJQtH1vqxkrBcv36k9gLK8jiI/GgTSFf/qMfjuW4WG7oXBGC/wzUSn
+    bRzItrRRkv6C0Yf7GVZvfmxcXpTy9B6fsH29VmNqRSK8BrvocPaRNlyWYAv5ghQU
+    f8xyaFUyVTosaxjUs6dY4hzb3EjonfuXZJznV/ThoNhNg+ldpWJI8A==
+    -----END RSA PRIVATE KEY-----
+
+# Job Manager configuration
+jobManager:
+  maxConcurentJobs: 4
+
+# LiveBundle QR Code service configuration
+qrcode:
+  url: http://livebundle-qrcode:3000
+  margin: 1
+  width: 250
+
+# SDK configuration
+task:
+  prepare:
+    steps:
+      - yarn install
+  bundle:
+    - dev: true
+      entry: index.js
+      platform: ios
+    - dev: false
+      entry: index.js
+      platform: ios
+    - dev: true
+      entry: index.js
+      platform: android
+    - dev: false
+      entry: index.js
+      platform: android
+  # LiveBundle Store service configuration
+  upload:
+    url: http://livebundle-store:3000
+
+# Server configuration
+server:
+  host: 0.0.0.0
+  port: 3000

--- a/packages/livebundle-github/package.json
+++ b/packages/livebundle-github/package.json
@@ -8,10 +8,11 @@
   "scripts": {
     "build": "yarn clean && yarn compile",
     "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo",
-    "compile": "tsc -b tsconfig.build.json",    
+    "compile": "tsc -b tsconfig.build.json",
     "docker:build": "yarn build && docker build -t livebundle/ghapp .",
     "prepublishOnly": "yarn build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "mocha"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -21,6 +22,7 @@
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "fs-extra": "^9.0.0",
+    "livebundle-cli": "^0.1.8",
     "livebundle-sdk": "^0.1.6",
     "livebundle-utils": "^0.1.3",
     "shelljs": "^0.8.4"

--- a/packages/livebundle-github/src/JobRunner.ts
+++ b/packages/livebundle-github/src/JobRunner.ts
@@ -1,8 +1,16 @@
 import { Octokit } from "@octokit/rest";
 import debug from "debug";
 import fs from "fs-extra";
-import type { Config as CliConfig } from "livebundle-cli";
-import { BundleTask, LiveBundleTask, TaskRunner } from "livebundle-sdk";
+import {
+  Config as CliConfig,
+  configSchema as cliConfigSchema,
+} from "livebundle-cli";
+import {
+  BundleTask,
+  LiveBundleTask,
+  TaskRunner,
+  taskSchema,
+} from "livebundle-sdk";
 import { createTmpDir, loadConfig } from "livebundle-utils";
 import path from "path";
 import shell from "shelljs";
@@ -43,13 +51,16 @@ export class JobRunner {
 
       let taskToRun = this.task;
       if (userConfigFile) {
-        const userConfig = loadConfig<CliConfig>({
+        const userConfig = await loadConfig<CliConfig>({
           configPath: path.resolve(userConfigFile),
+          refSchemas: [taskSchema],
+          schema: cliConfigSchema,
         });
         if (userConfig?.github?.task) {
-          taskToRun = loadConfig<LiveBundleTask>({
+          taskToRun = await loadConfig<LiveBundleTask>({
             config: userConfig.github.task,
             defaultConfig: this.task,
+            schema: taskSchema,
           });
         }
       }

--- a/packages/livebundle-github/src/index.ts
+++ b/packages/livebundle-github/src/index.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import program from "commander";
 import fs from "fs-extra";
+import { taskSchema } from "livebundle-sdk";
 import { loadConfig } from "livebundle-utils";
 import path from "path";
 import { GitHubAppServer } from "./GitHubAppServer";
 import { JobManager } from "./JobManager";
 import { JobRunner } from "./JobRunner";
 import log from "./log";
+import { configSchema } from "./schemas";
 import { Config } from "./types";
 import { JWTIssuer } from "./utils/JWTIssuer";
 import { QRCodeUrlBuilder } from "./utils/QRCodeUrlBuilder";
@@ -18,12 +20,14 @@ program.version(pJson.version);
 
 program
   .option("--config <string>", "path to the config")
-  .action(({ config }: { config?: string }) => {
+  .action(async ({ config }: { config?: string }) => {
     const defaultConfigPath = path.resolve(__dirname, "../config/default.yaml");
-    const conf = loadConfig<Config>({
+    const conf = await loadConfig<Config>({
       configPath: config,
       defaultConfigPath,
       defaultFileName: "livebundle-github",
+      refSchemas: [taskSchema],
+      schema: configSchema,
     });
     log(`conf: ${JSON.stringify(conf, null, 2)}`);
     const jwtIssuer = new JWTIssuer(conf.github);

--- a/packages/livebundle-github/src/schemas/config.json
+++ b/packages/livebundle-github/src/schemas/config.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/github-config.json",
+  "type": "object",
+  "properties": {
+    "github": {
+      "type": "object",
+      "properties": {
+        "appIdentifier": {
+          "type": "number"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        }
+      },
+      "required": ["appIdentifier", "clientId", "clientSecret", "privateKey"]
+    },
+    "jobManager": {
+      "type": "object",
+      "properties": {
+        "maxConcurentJobs": {
+          "type": "number",
+          "minimum": 1
+        }
+      }
+    },
+    "qrcode": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "pattern": "^http://[^:]+:\\d+$"
+        },
+        "margin": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": { "$data": "1/width" }
+        },
+        "width": {
+          "type": "number",
+          "minimum": 100
+        }
+      }
+    },
+    "task": {
+      "$ref": "sdk-task.json"
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "format": "hostname"
+        },
+        "port": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    }
+  },
+  "required": ["github"]
+}

--- a/packages/livebundle-github/src/schemas/index.ts
+++ b/packages/livebundle-github/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import configSchema from "./config.json";
+export { configSchema };

--- a/packages/livebundle-github/test/config.test.ts
+++ b/packages/livebundle-github/test/config.test.ts
@@ -1,0 +1,28 @@
+import { doesNotReject, rejects } from "assert";
+import { taskSchema } from "livebundle-sdk";
+import { loadConfig } from "livebundle-utils";
+import "mocha";
+import path from "path";
+import { configSchema } from "../src/schemas";
+
+describe("config", () => {
+  it("should fail loading default config", async () => {
+    await rejects(
+      loadConfig({
+        configPath: path.resolve(__dirname, "../config/default.yaml"),
+        refSchemas: [taskSchema],
+        schema: configSchema,
+      }),
+    );
+  });
+
+  it("should not fail loading sample config", async () => {
+    await doesNotReject(
+      loadConfig({
+        configPath: path.resolve(__dirname, "../config/sample.yaml"),
+        refSchemas: [taskSchema],
+        schema: configSchema,
+      }),
+    );
+  });
+});

--- a/packages/livebundle-github/tsconfig.build.json
+++ b/packages/livebundle-github/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./src/**/*.json"],
   "references": [
     {
       "path": "../livebundle-cli/tsconfig.build.json"

--- a/packages/livebundle-qrcode/src/index.ts
+++ b/packages/livebundle-qrcode/src/index.ts
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 import { loadConfig } from "livebundle-utils";
 import path from "path";
 import { QRCodeServer } from "./QRCodeServer";
+import { configSchema } from "./schemas";
 import { Config } from "./types";
 
 const pJsonPath = path.resolve(__dirname, "..", "package.json");
@@ -13,12 +14,13 @@ program.version(pJson.version);
 
 program
   .option("--config <string>", "path to config file")
-  .action(({ config }: { config?: string }) => {
+  .action(async ({ config }: { config?: string }) => {
     const defaultConfigPath = path.resolve(__dirname, "../config/default.yaml");
-    const conf = loadConfig<Config>({
+    const conf = await loadConfig<Config>({
       configPath: config,
       defaultConfigPath,
       defaultFileName: "livebundle-qrcode",
+      schema: configSchema,
     });
     new QRCodeServer(conf).start();
   })

--- a/packages/livebundle-qrcode/src/schemas/config.json
+++ b/packages/livebundle-qrcode/src/schemas/config.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/qrcode-config.json",
+  "properties": {
+    "server": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "format": "hostname"
+        },
+        "port": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    },
+    "qrcode": {
+      "type": "object",
+      "properties": {
+        "margin": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": { "$data": "1/width" }
+        },
+        "width": {
+          "type": "number",
+          "minimum": 100
+        }
+      }
+    }
+  }
+}

--- a/packages/livebundle-qrcode/src/schemas/index.ts
+++ b/packages/livebundle-qrcode/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import configSchema from "./config.json";
+export { configSchema };

--- a/packages/livebundle-qrcode/test/config.test.ts
+++ b/packages/livebundle-qrcode/test/config.test.ts
@@ -1,0 +1,18 @@
+import { doesNotReject } from "assert";
+import { taskSchema } from "livebundle-sdk";
+import { loadConfig } from "livebundle-utils";
+import "mocha";
+import path from "path";
+import { configSchema } from "../src/schemas";
+
+describe("config", () => {
+  it("should not fail loading default config", async () => {
+    await doesNotReject(
+      loadConfig({
+        configPath: path.resolve(__dirname, "../config/default.yaml"),
+        refSchemas: [taskSchema],
+        schema: configSchema,
+      }),
+    );
+  });
+});

--- a/packages/livebundle-qrcode/tsconfig.build.json
+++ b/packages/livebundle-qrcode/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./src/**/*.json"],
   "references": [
     {
       "path": "../livebundle-utils/tsconfig.build.json"

--- a/packages/livebundle-sdk/src/index.ts
+++ b/packages/livebundle-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./LiveBundleCli";
 export * from "./LiveBundleSdk";
 export * from "./parseAssetsFile";
+export * from "./schemas";
 export * from "./TaskRunner";
 export * from "./types";

--- a/packages/livebundle-sdk/src/schemas/index.ts
+++ b/packages/livebundle-sdk/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import taskSchema from "./task.json";
+export { taskSchema };

--- a/packages/livebundle-sdk/src/schemas/task.json
+++ b/packages/livebundle-sdk/src/schemas/task.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/sdk-task.json",
+  "type": "object",
+  "properties": {
+    "prepare": {
+      "type": "object",
+      "properties": {
+        "steps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "bundle": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dev": {
+            "type": "boolean"
+          },
+          "entry": {
+            "type": "string"
+          },
+          "platform": {
+            "enum": ["android", "ios"]
+          }
+        }
+      }
+    },
+    "upload": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "pattern": "^http://[^:]+:\\d+$"
+        }
+      }
+    }
+  }
+}

--- a/packages/livebundle-sdk/tsconfig.build.json
+++ b/packages/livebundle-sdk/tsconfig.build.json
@@ -6,7 +6,7 @@
     "typeRoots": ["./typings"],
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./src/**/*.json"],
   "references": [
     {
       "path": "../livebundle-store/tsconfig.build.json"

--- a/packages/livebundle-store/src/cli.ts
+++ b/packages/livebundle-store/src/cli.ts
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 import { loadConfig } from "livebundle-utils";
 import path from "path";
 import { LiveBundleStore } from "./LiveBundleStore";
+import { configSchema } from "./schemas";
 import { Config } from "./types";
 
 const pJsonPath = path.resolve(__dirname, "..", "package.json");
@@ -14,12 +15,13 @@ program.version(pJson.version);
 program
   .option("--config <string>", "path to the config")
   .parse(process.argv)
-  .action(({ config }: { config?: string }) => {
+  .action(async ({ config }: { config?: string }) => {
     const defaultConfigPath = path.resolve(__dirname, "../config/default.yaml");
-    const conf = loadConfig<Config>({
+    const conf = await loadConfig<Config>({
       configPath: config,
       defaultConfigPath,
       defaultFileName: "livebundle-store",
+      schema: configSchema,
     });
     new LiveBundleStore(conf).start();
   })

--- a/packages/livebundle-store/src/index.ts
+++ b/packages/livebundle-store/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./schemas";
 export * from "./types";

--- a/packages/livebundle-store/src/schemas/config.json
+++ b/packages/livebundle-store/src/schemas/config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/store-config.json",
+  "properties": {
+    "server": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "format": "hostname"
+        },
+        "port": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    },
+    "store": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/livebundle-store/src/schemas/index.ts
+++ b/packages/livebundle-store/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import configSchema from "./config.json";
+export { configSchema };

--- a/packages/livebundle-store/test/config.test.ts
+++ b/packages/livebundle-store/test/config.test.ts
@@ -1,0 +1,16 @@
+import { doesNotReject } from "assert";
+import { loadConfig } from "livebundle-utils";
+import "mocha";
+import path from "path";
+import { configSchema } from "../src/schemas";
+
+describe("config", () => {
+  it("should not fail loading default config", async () => {
+    await doesNotReject(
+      loadConfig({
+        configPath: path.resolve(__dirname, "../config/default.yaml"),
+        schema: configSchema,
+      }),
+    );
+  });
+});

--- a/packages/livebundle-store/tsconfig.build.json
+++ b/packages/livebundle-store/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"],
+  "include": ["./src/**/*", "./src/**/*.json"],
   "references": [
     {
       "path": "../livebundle-utils/tsconfig.build.json"

--- a/packages/livebundle-utils/package.json
+++ b/packages/livebundle-utils/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "ajv": "^6.12.2",
     "debug": "^4.1.1",
     "fs-extra": "^9.0.0",
     "js-yaml": "^3.13.1",

--- a/packages/livebundle-utils/src/index.ts
+++ b/packages/livebundle-utils/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./createTmpDir";
 export * from "./loadConfig";
+export * from "./loadYamlFile";
+export * from "./schemaValidate";

--- a/packages/livebundle-utils/src/loadYamlFile.ts
+++ b/packages/livebundle-utils/src/loadYamlFile.ts
@@ -1,0 +1,18 @@
+import fs from "fs-extra";
+import yaml from "js-yaml";
+
+export async function loadYamlFile<T>(filePath: string): Promise<T> {
+  if (!(await fs.pathExists(filePath))) {
+    throw new Error(`Path to yaml file does not exist (${filePath})`);
+  }
+
+  const file = await fs.readFile(filePath, {
+    encoding: "utf8",
+  });
+
+  try {
+    return yaml.safeLoad(file);
+  } catch (e) {
+    throw new Error(`YAML file load failed (${filePath}): ${e.message}`);
+  }
+}

--- a/packages/livebundle-utils/src/schemaValidate.ts
+++ b/packages/livebundle-utils/src/schemaValidate.ts
@@ -1,0 +1,35 @@
+import Ajv from "ajv";
+import debug from "debug";
+
+const log = debug("livebundle-utils:schemaValidate");
+
+export function schemaValidate<T>({
+  data,
+  refSchemas = [],
+  schema,
+}: {
+  data: T;
+  refSchemas?: Record<string, unknown>[];
+  schema: Record<string, unknown>;
+}): void {
+  log(`data: ${JSON.stringify(data, null, 2)}
+refSchemas: ${refSchemas.map((s) => s["$id"])}
+schema: ${schema["$id"]}}`);
+
+  const ajv = new Ajv({ $data: true });
+  for (const refSchema of refSchemas) {
+    ajv.addSchema(refSchema);
+  }
+
+  let validate;
+  try {
+    validate = ajv.compile(schema);
+  } catch (e) {
+    throw new Error(`Schema compilation failed: ${e.message}`);
+  }
+
+  const isValid = validate(data);
+  if (!isValid) {
+    throw new Error(`Invalid data: ${ajv.errorsText(validate.errors)}`);
+  }
+}

--- a/packages/livebundle-utils/tsconfig.build.json
+++ b/packages/livebundle-utils/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["./src/**/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "lib": ["es2018"],
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": "./packages",
     "paths": {
       "livebundle-*": ["livebundle-*/src"]
-    }
+    },
+    "resolveJsonModule": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,7 +1616,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==


### PR DESCRIPTION
Fail early and clearly in case some configuration provided to the cli or any services is invalid.

**What's changed**

- `loadConfig<T>` function is now asynchronous
- Extracted YAML file loading logic from `loadConfig<T>` to a dedicated new function `loadYamlFile<T>`

**What's new**

- Added JSON schemas for LiveBundle store, qrcode, github and cli configurations.
- Added JSON schema for LiveBundle SDK task (referenced in configuration schemas)
- Added dependency on [ajv](https://github.com/ajv-validator/ajv) (used for schema validation) to `livebundle-utils`
- Added new function `schemaValidate` to `livebundle-utils`, using [ajv](https://github.com/ajv-validator/ajv) to validate an object against a given schema.
- Updated. `loadConfig<T>` function, now accepting two more properties `schema` and `refSchemas` to be used to provide a schema (and optional reference schemas) to validate configuration against.
- Updated all existing client calls to `loadConfig<T>` to provide the proper schemas.
- Added [resolveJsonModule](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#new---resolvejsonmodule) property to `tsconfig.json` and `tsconfig.build.json`. Needed to allow direct import of json files.
- Added simple tests just to make sure that default configurations could still be properly loaded after these changes. More tests will come in a future PR, specifically dedicated to the improvement of our test coverage.

**Remarks**

- The URIs specified in the schemas (`$id`) are only used to identify the schemas (and required to properly use schema references). It is totally OK for these URIs not to really exist. According to JSON schema specifiation, validators should not expect to be able to download the schemas from these URIs.
- The update of `"include": ["src/**/*"]` to `"include": ["./src/**/*", "./src/**/*.json"]` in modules `tsconfig.build.json` might seem unnecessary. It is however needed. See [this issue](https://github.com/microsoft/TypeScript/issues/25636) for reference.

Closes https://github.com/electrode-io/livebundle/issues/16