### PR TITLE
Update react-native version range in livebundle android lib

### DIFF
--- a/native-libs/android/lib/build.gradle
+++ b/native-libs/android/lib/build.gradle
@@ -19,8 +19,9 @@ android {
 }
 
 dependencies {
-    //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    // See https://github.com/electrode-io/livebundle/pull/28
+    // before potentially updating react native version range below
+    implementation 'com.facebook.react:react-native:[0.60,)'  // From node_modules
     implementation 'me.dm7.barcodescanner:zxing:1.9.13'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'


### PR DESCRIPTION
Unfortunately it appears we have to go back to the former way for this react native version.
Initially I was using `"com.facebook.react:react-native:+"` then switched to `[0.60,)` due to a publication issue in nexus. Now that it has been switched back to `+`, even though the `//noinspection GradleDynamicVersion` has been added, nexus does fail on one of the validation steps (pom validation) when trying to publish to maven central :( 

<img width="660" alt="Screen Shot 2020-06-09 at 1 00 19 PM" src="https://user-images.githubusercontent.com/1390588/84194357-c278f000-aa51-11ea-9a77-8479e270c4f3.png">
