### PR TITLE
Add basic access key construct for store uploads

### DIFF
--- a/packages/livebundle-github/config/default.yaml
+++ b/packages/livebundle-github/config/default.yaml
@@ -67,6 +67,9 @@ task:
       platform: android
   # LiveBundle Store service configuration
   upload:
+    # Store access key
+    # accessKey:
+    # Store url
     url: http://livebundle-store:3000
 
 # Server configuration

--- a/packages/livebundle-github/src/program.ts
+++ b/packages/livebundle-github/src/program.ts
@@ -48,7 +48,9 @@ export default function program(): commander.Command {
         new ExecCmdImpl(),
       );
       const qrCodeUrlBuilder = new QRCodeUrlBuilderImpl(conf.qrcode);
-      const httpCli = new LiveBundleHttpCli(conf.task.upload.url);
+      const httpCli = new LiveBundleHttpCli(conf.task.upload.url, {
+        accessKey: conf.task.upload.accessKey,
+      });
       const sdk = new LiveBundleSdk(httpCli);
       const taskRunner = new TaskRunnerImpl(sdk);
       const jobRunner = new JobRunnerImpl(

--- a/packages/livebundle-sdk/src/schemas/task.json
+++ b/packages/livebundle-sdk/src/schemas/task.json
@@ -34,6 +34,9 @@
     "upload": {
       "type": "object",
       "properties": {
+        "accessKey": {
+          "type": "string"
+        },
         "url": {
           "type": "string",
           "pattern": "^http://[^:]+:\\d+$"

--- a/packages/livebundle-sdk/src/types/index.ts
+++ b/packages/livebundle-sdk/src/types/index.ts
@@ -8,6 +8,7 @@ export interface CliBundle {
 }
 
 export interface UploadTask {
+  accessKey?: string;
   url: string;
 }
 

--- a/packages/livebundle-sdk/test/LiveBundleSdk.test.ts
+++ b/packages/livebundle-sdk/test/LiveBundleSdk.test.ts
@@ -15,6 +15,7 @@ describe("LiveBundleSdk", () => {
   describe("uploadPackage", () => {
     it("should succeed", async () => {
       const httpCli = sandbox.createStubInstance(LiveBundleHttpCli);
+
       const uploadRes = {
         id: "4a1aaa5b-89ae-477f-b6d7-9747131750d7",
         bundles: [
@@ -34,7 +35,7 @@ describe("LiveBundleSdk", () => {
         timestamp: 1591640289863,
       };
       httpCli.uploadPackage.resolves(uploadRes);
-      const sut = new LiveBundleSdk(httpCli);
+      const sut = new LiveBundleSdk((httpCli as unknown) as LiveBundleHttpCli);
       const res = await sut.uploadPackage({
         bundles: [
           {
@@ -59,7 +60,7 @@ describe("LiveBundleSdk", () => {
     it("should succeed if there is new assets", async () => {
       const httpCli = sandbox.createStubInstance(LiveBundleHttpCli);
       httpCli.assetsDelta.resolves(["46d1173c53d96832e868151c1648ea42"]);
-      const sut = new LiveBundleSdk(httpCli);
+      const sut = new LiveBundleSdk((httpCli as unknown) as LiveBundleHttpCli);
       await sut.uploadAssets([
         {
           files: [path.join(fixturesPath, "loader.png")],
@@ -71,7 +72,7 @@ describe("LiveBundleSdk", () => {
     it("should succeed if there is no new assets", async () => {
       const httpCli = sandbox.createStubInstance(LiveBundleHttpCli);
       httpCli.assetsDelta.resolves([]);
-      const sut = new LiveBundleSdk(httpCli);
+      const sut = new LiveBundleSdk((httpCli as unknown) as LiveBundleHttpCli);
       await sut.uploadAssets([
         {
           files: [path.join(fixturesPath, "loader.png")],

--- a/packages/livebundle-store/config/default.yaml
+++ b/packages/livebundle-store/config/default.yaml
@@ -1,3 +1,5 @@
+accessKeys: []
+
 server:
   host: 0.0.0.0
   port: 3000

--- a/packages/livebundle-store/src/schemas/config.json
+++ b/packages/livebundle-store/src/schemas/config.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://electrode.io/schemas/store-config.json",
   "properties": {
+    "accessKeys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "server": {
       "type": "object",
       "properties": {

--- a/packages/livebundle-store/src/types/index.ts
+++ b/packages/livebundle-store/src/types/index.ts
@@ -33,6 +33,7 @@ export interface ServerPaths {
 }
 
 export interface Config {
+  accessKeys: string[];
   server: ServerConfig;
   store: StoreConfig;
 }

--- a/packages/livebundle/config/default.yaml
+++ b/packages/livebundle/config/default.yaml
@@ -33,5 +33,7 @@ task:
 
   # Store configuration
   upload:
+    # LiveBundle store access key
+    # accessKey:
     # LiveBundle store server url
     url: http://localhost:3000

--- a/packages/livebundle/src/upload.ts
+++ b/packages/livebundle/src/upload.ts
@@ -12,7 +12,9 @@ export async function upload(
   conf: Config,
   { enableSpinners = true }: { enableSpinners?: boolean } = {},
 ): Promise<Package> {
-  const httpCli = new LiveBundleHttpCli(conf.task.upload.url);
+  const httpCli = new LiveBundleHttpCli(conf.task.upload.url, {
+    accessKey: conf.task.upload.accessKey,
+  });
   const sdk = new LiveBundleSdk(httpCli);
   let spinner: ora.Ora | undefined;
 


### PR DESCRIPTION
No access keys are set by default, so any machine with access to the store can upload packages to it.

One or more free form access key(s) strings can be added to the store server configuration (via top level `accessKeys` array). If at least one access key is configured server side, any client http requests to upload packages or assets to the store, should set the `LB-Access-Key` header with a valid access key.

The access key can conveniently be set client side (livebundle-github and livebundle cli) through configuration, by setting `accessKey` in the `task.upload` section :

```
upload:
  accessKey: sample-access-key
  url: http://livebundle-store:3000
```

Closes https://github.com/electrode-io/livebundle/issues/4