### PR TITLE
Update store status route

### DIFF
--- a/packages/livebundle-store/src/LiveBundleStore.ts
+++ b/packages/livebundle-store/src/LiveBundleStore.ts
@@ -296,7 +296,7 @@ export class LiveBundleStore {
       // Swallow
     });
 
-    this.app.get("/status", (req, res) => {
+    this.app.get("*/status", (req, res) => {
       res.writeHead(200, {
         "Transfer-Encoding": "chunked",
       });


### PR DESCRIPTION
Minor update to `GET /status` route to make it reachable through any combination of url segments.
When reaching metro server *(LiveBundle store is emulating metro)*, React Native will try to reach [`/status` endpoint on the complete url](https://github.com/facebook/react-native/blob/b4785e514430dc3ba45ed6d136ec63574be88e26/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java#L510-L512). In LiveBundle case, the url is set to `/packages/[package-id]`.
This was resulting in a 404 to be sent back to React Native as can be seen in the logs below.
```
express:router <anonymous>: /packages/5c47f984-8492-4b7d-baee-d77bde1fe0fd/status +0ms
finalhandler default 404 +0ms
```
Not exactly sure of any consequences of this, but now with this PR, we will properly return expected response to React Native client.
Keeping the route wildcarded so that we can call `status` on any segment. Not a problem and at least in the getting started guide on LiveBundle store we can keep the instruction to browse to `http://localhost:3000/status` to validate LiveBundle store readiness.