### PR TITLE
Update Docker images to use non root user

### DIFF
--- a/packages/livebundle-github/Dockerfile.dev
+++ b/packages/livebundle-github/Dockerfile.dev
@@ -17,4 +17,5 @@ RUN yarn workspace livebundle-github install --prod
 EXPOSE 3000
 ENV DEBUG *,-babel*
 WORKDIR /usr/src/app/packages/livebundle-github
+USER 1000
 CMD ["yarn", "start"]

--- a/packages/livebundle-github/Dockerfile.prod
+++ b/packages/livebundle-github/Dockerfile.prod
@@ -8,4 +8,5 @@ RUN apk add --no-cache git
 WORKDIR /usr/src/app
 COPY --from=0 /usr/src/app .
 EXPOSE 3000
+USER 1000
 CMD [ "yarn", "livebundle-github" ]

--- a/packages/livebundle-qrcode/Dockerfile.dev
+++ b/packages/livebundle-qrcode/Dockerfile.dev
@@ -8,4 +8,5 @@ RUN yarn workspace livebundle-qrcode install --prod
 EXPOSE 3000
 ENV DEBUG *
 WORKDIR /usr/src/app/packages/livebundle-qrcode
+USER 1000
 CMD ["yarn", "start"]

--- a/packages/livebundle-qrcode/Dockerfile.prod
+++ b/packages/livebundle-qrcode/Dockerfile.prod
@@ -7,4 +7,5 @@ FROM node:12-alpine
 WORKDIR /usr/src/app
 COPY --from=0 /usr/src/app .
 EXPOSE 3000
+USER 1000
 CMD [ "yarn", "livebundle-qrcode" ]

--- a/packages/livebundle-store/Dockerfile.dev
+++ b/packages/livebundle-store/Dockerfile.dev
@@ -8,4 +8,5 @@ RUN yarn workspace livebundle-store install --prod
 EXPOSE 3000
 ENV DEBUG *
 WORKDIR /usr/src/app/packages/livebundle-store
+USER 1000
 CMD ["yarn", "start"]

--- a/packages/livebundle-store/Dockerfile.prod
+++ b/packages/livebundle-store/Dockerfile.prod
@@ -7,4 +7,5 @@ FROM node:12-alpine
 WORKDIR /usr/src/app
 COPY --from=0 /usr/src/app .
 EXPOSE 3000
+USER 1000
 CMD [ "yarn", "livebundle-store" ]


### PR DESCRIPTION
Run the different services using the `node` user *([uid 1000 as defined in node alpine images](https://github.com/nodejs/docker-node/blob/0acac6b0224a313d5e6c4b233bf38c1eaaf11849/12/alpine3.11/Dockerfile#L5-L6))*
instead of running the services using default `root` user.

Mostly to follow recommended security practices but also because some (most) K8s clusters, will not allow to run such root user containers, based on their Pod Security Policies