### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiveBundle
 
-[![ci][1]][2]
+[![ci][1]][2] [![codecov][3]][4]
 
 **This project is still in incubation.
 Heavy work is in progess to get to a proper initial MVP state.
@@ -50,3 +50,5 @@ Further development documentation material detailing technology stack, developme
 
 [1]: https://github.com/electrode-io/livebundle/workflows/ci/badge.svg
 [2]: https://github.com/electrode-io/livebundle/actions
+[3]: https://codecov.io/gh/electrode-io/livebundle/branch/master/graph/badge.svg?token=97VWVN63G0
+[4]: https://codecov.io/gh/electrode-io/livebundle


### PR DESCRIPTION
Add [codecov](https://codecov.io/) badge to README _(coverage % of master branch)_

To be noted that total coverage is used by default instead of line coverage. This is better, but it explains why reported coverage is currently 94% instead of stated 100% (which is true of line coverage). Still need some work there to get to 100% 😄 