### PR TITLE
Increase mocha test timeout to 5s

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["ts"],
   "spec": "test/**/*.test.ts",
-  "require": ["ts-node/register", "source-map-support/register"]
+  "require": ["ts-node/register", "source-map-support/register"],
+  "timeout": 5000
 }


### PR DESCRIPTION
Noticed some tests failing randomly when running on GitHub actions agents, running into timeouts.
Mocha defaults test timeout to 2s. This PR increases test timeout to 5s.
Will do the same in electrode-native repository as it seems we are running into a similar issue.