### PR TITLE
Update json schema with uri format instead of pattern

### DIFF
--- a/packages/livebundle-github/src/schemas/config.json
+++ b/packages/livebundle-github/src/schemas/config.json
@@ -32,7 +32,7 @@
       "properties": {
         "url": {
           "type": "string",
-          "pattern": "^http://[^:]+:\\d+$"
+          "format": "uri"
         },
         "margin": {
           "type": "number",

--- a/packages/livebundle-sdk/src/schemas/task.json
+++ b/packages/livebundle-sdk/src/schemas/task.json
@@ -39,7 +39,7 @@
         },
         "url": {
           "type": "string",
-          "pattern": "^http://[^:]+:\\d+$"
+          "format": "uri"
         }
       }
     }


### PR DESCRIPTION
Pattern was way too simple and naive.
Rather than trying to improve the regexp pattern, just use json schema built-in uri format.