### PR TITLE
Set Cache-Control header in QRCode service response

### DIFF
--- a/packages/livebundle-qrcode/src/QRCodeServer.ts
+++ b/packages/livebundle-qrcode/src/QRCodeServer.ts
@@ -54,6 +54,7 @@ export class QRCodeServer {
       const { margin: defaultMargin, width: defaultWidth } = this.config.qrcode;
       this.log(`Encoding ${content}`);
       res.writeHead(200, {
+        "Cache-Control": "public, max-age=604800, immutable",
         "Content-Type": "image/png",
       });
       qrcode.toFileStream(res, content, {

--- a/packages/livebundle-qrcode/test/QRCodeServer.test.ts
+++ b/packages/livebundle-qrcode/test/QRCodeServer.test.ts
@@ -70,10 +70,19 @@ describe("QRCodeServer", () => {
         });
       });
 
-      it("should have Content-Type header set to image/png", async () => {
+      it("should have Content-Type header set to 'image/png'", async () => {
         await test(defaultConfig, async (req) => {
           const res = await req.get("/foo");
           expect(res.get("Content-Type")).eql("image/png");
+        });
+      });
+
+      it("should have Cache-Control header set to 'public, max-age=604800, immutable'", async () => {
+        await test(defaultConfig, async (req) => {
+          const res = await req.get("/foo");
+          expect(res.get("Cache-Control")).eql(
+            "public, max-age=604800, immutable",
+          );
         });
       });
 


### PR DESCRIPTION
Small optimization by setting aggressive caching in QRCode service response, given that the QRCode, once generated, will never change.

For example if a client browser is making a GET call to `http://livebundle-qrcode/4a1aaa5b-89ae-477f-b6d7-9747131750d7`, it will return a png of the QRCode encoding `4a1aaa5b-89ae-477f-b6d7-9747131750d7` data. 

There is no point to do a round trip to the server, for any subsequent call to the same URL from same browser, as it will anyway return the exact same QRCode image.
