### PR TITLE
Allow providing some GitHub app config props as env vars

### DIFF
--- a/packages/livebundle-github-consumer/src/program.ts
+++ b/packages/livebundle-github-consumer/src/program.ts
@@ -15,6 +15,10 @@ import { JobRunnerImpl } from "./JobRunnerImpl";
 import { JWTIssuerImpl } from "./JWTIssuerImpl";
 import { OctokitFactoryImpl } from "./OctokitFactoryImpl";
 import { QRCodeUrlBuilderImpl } from "./QRCodeUrlBuilderImpl";
+import {
+  getErrorMessage,
+  reconciliateGitHubAppConfig,
+} from "./reconciliateGitHubAppConfig";
 import { configSchema } from "./schemas";
 import { Config } from "./types";
 
@@ -40,8 +44,12 @@ export default function program(): commander.Command {
         refSchemas: [taskSchema],
         schema: configSchema,
       });
+      const recGitHubAppConfig = reconciliateGitHubAppConfig(conf.github);
+      if (!recGitHubAppConfig.config) {
+        throw new Error(getErrorMessage(recGitHubAppConfig));
+      }
       console.log(JSON.stringify(conf, null, 2));
-      const jwtIssuer = new JWTIssuerImpl(conf.github);
+      const jwtIssuer = new JWTIssuerImpl(recGitHubAppConfig.config!);
       const gitHubApi = new GitHubApiImpl(
         jwtIssuer,
         new OctokitFactoryImpl(jwtIssuer),

--- a/packages/livebundle-github-consumer/src/reconciliateGitHubAppConfig.ts
+++ b/packages/livebundle-github-consumer/src/reconciliateGitHubAppConfig.ts
@@ -1,0 +1,79 @@
+import { GitHubAppConfig } from "./types";
+
+export function reconciliateGitHubAppConfig(
+  curConfig: Partial<GitHubAppConfig> | undefined = {},
+): {
+  ambiguousConfigProps: [string, string][];
+  missingConfigProps: [string, string][];
+  config?: GitHubAppConfig;
+} {
+  const envVarToConfigKey = {
+    LIVEBUNDLE_GITHUB_APPIDENTIFIER: "appIdentifier",
+    LIVEBUNDLE_GITHUB_CLIENTID: "clientId",
+    LIVEBUNDLE_GITHUB_CLIENTSECRET: "clientSecret",
+    LIVEBUNDLE_GITHUB_PRIVATEKEY: "privateKey",
+  };
+
+  const res: ReturnType<typeof reconciliateGitHubAppConfig> = {
+    ambiguousConfigProps: [],
+    missingConfigProps: [],
+    config: {} as GitHubAppConfig,
+  };
+
+  for (const [envVar, configKey] of Object.entries(envVarToConfigKey)) {
+    const envVarVal = process.env[envVar];
+    if (curConfig && curConfig[configKey] && envVarVal) {
+      // Config property is defined both in config and as an env var
+      res.ambiguousConfigProps.push([envVar, configKey]);
+    } else if ((!curConfig || !curConfig[configKey]) && envVarVal) {
+      // Config property is defined as an env var
+      res.config![configKey] = envVarVal;
+    } else if (curConfig && !curConfig[configKey] && !envVarVal) {
+      // Config property is defined nowhere
+      res.missingConfigProps.push([envVar, configKey]);
+    } else if (curConfig && curConfig[configKey] && !envVarVal) {
+      // Config property is defined in config
+      res.config![configKey] = curConfig[configKey];
+    }
+  }
+
+  if (
+    res.ambiguousConfigProps.length > 0 ||
+    res.missingConfigProps.length > 0
+  ) {
+    res.config = undefined;
+  } else {
+    // In case appIdentifier is coming from the env var
+    // we need to coerce it to a number (env var values
+    // are strings)
+    // In case its coming from config, it will be a noop
+    // @ts-ignore
+    res.config!.appIdentifier = parseInt(res.config!.appIdentifier);
+  }
+
+  return res;
+}
+
+export function getErrorMessage(
+  conf: ReturnType<typeof reconciliateGitHubAppConfig>,
+) {
+  const hasAmbiguousConfigProps = conf.ambiguousConfigProps.length > 0;
+  const hasMissingConfigProps = conf.missingConfigProps.length > 0;
+  return `${
+    hasAmbiguousConfigProps
+      ? `=== Ambiguous GitHub configuration properties ===
+${conf.ambiguousConfigProps.map(
+  ([env, prop]) =>
+    `- ${prop} is defined in config as well as environment variable ${env}\n`,
+)}`
+      : ""
+  }${
+    hasMissingConfigProps
+      ? `=== Missing GitHub configuration properties ===
+${conf.missingConfigProps.map(
+  ([env, prop]) =>
+    `- Missing ${prop} in config. Either set it in config or as environment variable ${env}\n`,
+)}`
+      : ""
+  }`;
+}

--- a/packages/livebundle-github-consumer/src/schemas/config.json
+++ b/packages/livebundle-github-consumer/src/schemas/config.json
@@ -18,8 +18,7 @@
         "privateKey": {
           "type": "string"
         }
-      },
-      "required": ["appIdentifier", "clientId", "clientSecret", "privateKey"]
+      }
     },
     "ignore": {
       "type": "array",
@@ -74,6 +73,5 @@
         }
       }
     }
-  },
-  "required": ["github"]
+  }
 }

--- a/packages/livebundle-github-consumer/src/types/index.ts
+++ b/packages/livebundle-github-consumer/src/types/index.ts
@@ -25,6 +25,7 @@ export interface GitHubAppConfig {
   appIdentifier: number;
   clientId: string;
   clientSecret: string;
+  [key: string]: any;
 }
 
 export interface QrCodeServiceConfig {

--- a/packages/livebundle-github-consumer/test/config.test.ts
+++ b/packages/livebundle-github-consumer/test/config.test.ts
@@ -1,4 +1,4 @@
-import { doesNotReject, rejects } from "assert";
+import { doesNotReject } from "assert";
 import { taskSchema } from "livebundle-sdk";
 import { loadConfig } from "livebundle-utils";
 import "mocha";
@@ -6,8 +6,8 @@ import path from "path";
 import { configSchema } from "../src/schemas";
 
 describe("config", () => {
-  it("should fail loading default config", async () => {
-    await rejects(
+  it("should not fail loading default config", async () => {
+    await doesNotReject(
       loadConfig({
         configPath: path.resolve(__dirname, "../config/default.yaml"),
         refSchemas: [taskSchema],

--- a/packages/livebundle-github-consumer/test/reconciliateGitHubAppConfig.test.ts
+++ b/packages/livebundle-github-consumer/test/reconciliateGitHubAppConfig.test.ts
@@ -1,0 +1,152 @@
+import { expect } from "chai";
+import "mocha";
+import {
+  getErrorMessage,
+  reconciliateGitHubAppConfig,
+} from "../src/reconciliateGitHubAppConfig";
+import { GitHubAppConfig } from "../src/types";
+
+const config: GitHubAppConfig = {
+  appIdentifier: 65645,
+  clientId: "Iv1.04849b1cb72ad0fa",
+  clientSecret: "14c640bb4946970807366672ba6bb077c7de7009",
+  privateKey: `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA3ddwHEVpGM3OXYNY2jro2bDZWzzuNEzwRxl7pgqwG7eWXEGe
+NDC+qwOuyclz/2qtqg83eJ9PvUnaG+vmwdbeu7dzkQuCtKFi4sFMCFbl6fZcbn0u
+NTfK5dHjjdaQjEqD+WZsTxec8NzMrMWOeJ07sZ3TsmWjXm3AZVn27Mnk0nnY6WIC
+6EwSI80pvDDkUHWrPE/WSHYVJWxsl6KpICAu73i2N2hplG13XEmP1TIMwoktSKB7
+h+9au+S3KkCdxXzFyN9hVBUZu8FcvbO8ZPSmb5bGyVw44pFQU9X39iqWZtMpc8V4
+A/qIwRYuf6mFcnvdwkpbuZkRJq06VFHeFsDe9wIDAQABAoIBAA+XWpvCDRbfMAfG
+eXIs/bx+/2e4Ko2mcqSsl9Idoi7wgjLNsc69NklSovAvpmVnG/l9xEpH+BS3ogqg
+U8F/1nue8xJYmsETLp39M9jKMrJ0zB4/0gWPfEUWsUWAtPwHKKtYlXghkrgi7Ieg
+AtlbQ5zCGOTK2+aBFCqLXh1aOyjHofBubcX/qMVwKqoC+cHtcqQVa3aAZPyovrt5
+M1zlUxWfhA/xqIT0PPSkgMrHZbScSBMMrbQ2JZ1EysySK2Mv43FQPGD5oNYZOyJx
+F1q8ZDVXvPsqN/pN3gsQ3wCzRCVgtkIpD2sglND+yte9GwVc3EVLQXIO1dRNYt1A
+ea2kBgECgYEA/63lxv6eRND8hIDnTFavdrfARJN9ZQhIPkFzRVS1GCxFKGUwBcCX
+Qr1fZsbJ4bm/hnxbrVgRGXv0oTuDrGDjVFvdjCFpK4GP6ZB1nNnRmxLhTTla0uXj
+1oh/9LUygPDYqjtxf9RyzzznxA7QumorWw+3wY8X/9Cw6lNIV+cQ04ECgYEA3h6s
+sClnniGE8LLqO1RpzNTJbM5vUsrl9zCBfXeQ4lqRKutbmgoKWCSO7hJQjC/qoLip
+sjyMc4a5R8RxlEb1yBA0+7PzFUJqS4LSpLjWZzHN6XMmBHihAbC31EHX6Wfsu8De
+m81D66w4bdtzmIpEMTWLcmi84LIuKIHL4+MdjncCgYEA67xhNCWEtXxepqjXGap/
+Ix2pmZDHN8T4HvZnpo/sXLpMlV8edN9KV42VDYSWklmZvhygxmWBdpa0SYg+8ktu
+rlP5I/+WITfXAYlg91pZiPpSYsoz9GljtWSrXWtHgl0N137xOeQeavcD1d+3EXlc
+Ohx2127guMuoopRhCjMQb4ECgYEAs81K5vMtYJErpxh9iXdkiZ26S6yz6uY5z6Zh
+O+pcyw6bMo4AwandA8rcNJV4xHJJUL8LBzACVcY6F4FKm8fxT3jnGtVpMc1odCW7
+VAIX9MMZNx+yJ65qTw75UAXYvKUWukl/Kcm4cH8h0rPxWAqc9uSsM/na41z5BmtD
+W/7OPzMCgYBJQtH1vqxkrBcv36k9gLK8jiI/GgTSFf/qMfjuW4WG7oXBGC/wzUSn
+bRzItrRRkv6C0Yf7GVZvfmxcXpTy9B6fsH29VmNqRSK8BrvocPaRNlyWYAv5ghQU
+f8xyaFUyVTosaxjUs6dY4hzb3EjonfuXZJznV/ThoNhNg+ldpWJI8A==
+-----END RSA PRIVATE KEY-----`,
+};
+
+describe("reconciliateGitHubAppConfig", () => {
+  afterEach(() => {
+    delete process.env.LIVEBUNDLE_GITHUB_APPIDENTIFIER;
+    delete process.env.LIVEBUNDLE_GITHUB_CLIENTID;
+    delete process.env.LIVEBUNDLE_GITHUB_CLIENTSECRET;
+    delete process.env.LIVEBUNDLE_GITHUB_PRIVATEKEY;
+  });
+
+  it("should return reconciliated config [config only]", () => {
+    const res = reconciliateGitHubAppConfig(config);
+    expect(res.config).not.undefined;
+    expect(res.config).deep.equal(config);
+  });
+
+  it("should return reconciliated config [env vars only]", () => {
+    process.env.LIVEBUNDLE_GITHUB_APPIDENTIFIER = `${config.appIdentifier}`;
+    process.env.LIVEBUNDLE_GITHUB_CLIENTID = config.clientId;
+    process.env.LIVEBUNDLE_GITHUB_CLIENTSECRET = config.clientSecret;
+    process.env.LIVEBUNDLE_GITHUB_PRIVATEKEY = config.privateKey;
+    const res = reconciliateGitHubAppConfig();
+    expect(res.config).not.undefined;
+    expect(res.config).deep.equal(config);
+  });
+
+  it("should return reconciliated config [mix config & env vars]", () => {
+    const partialConfig = Object.assign({}, config);
+    delete partialConfig.privateKey;
+    process.env.LIVEBUNDLE_GITHUB_PRIVATEKEY = config.privateKey;
+    const res = reconciliateGitHubAppConfig(partialConfig);
+    expect(res.config).not.undefined;
+    expect(res.config).deep.equal(config);
+  });
+
+  it("should return an undefined config if there are ambiguous config props", () => {
+    process.env.LIVEBUNDLE_GITHUB_PRIVATEKEY = config.privateKey;
+    const res = reconciliateGitHubAppConfig(config);
+    expect(res.config).undefined;
+  });
+
+  it("should return ambiguous config props", () => {
+    process.env.LIVEBUNDLE_GITHUB_CLIENTID = config.clientId;
+    process.env.LIVEBUNDLE_GITHUB_PRIVATEKEY = config.privateKey;
+    const res = reconciliateGitHubAppConfig(config);
+    expect(res.ambiguousConfigProps.length).eql(2);
+    expect(res.ambiguousConfigProps[0]).eql([
+      "LIVEBUNDLE_GITHUB_CLIENTID",
+      "clientId",
+    ]);
+    expect(res.ambiguousConfigProps[1]).eql([
+      "LIVEBUNDLE_GITHUB_PRIVATEKEY",
+      "privateKey",
+    ]);
+  });
+
+  it("should return an undefined config if there are missing config props", () => {
+    const partialConfig = Object.assign({}, config);
+    delete partialConfig.privateKey;
+    const res = reconciliateGitHubAppConfig(partialConfig);
+    expect(res.config).undefined;
+  });
+
+  it("should return missing config props", () => {
+    const partialConfig = Object.assign({}, config);
+    delete partialConfig.clientId;
+    delete partialConfig.privateKey;
+    const res = reconciliateGitHubAppConfig(partialConfig);
+    expect(res.missingConfigProps.length).eql(2);
+    expect(res.missingConfigProps[0]).eql([
+      "LIVEBUNDLE_GITHUB_CLIENTID",
+      "clientId",
+    ]);
+    expect(res.missingConfigProps[1]).eql([
+      "LIVEBUNDLE_GITHUB_PRIVATEKEY",
+      "privateKey",
+    ]);
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("should return expected error message [ambiguous and missing properties]", () => {
+    const errorMessage = getErrorMessage({
+      ambiguousConfigProps: [["LIVEBUNDLE_GITHUB_CLIENTID", "clientId"]],
+      missingConfigProps: [["LIVEBUNDLE_GITHUB_PRIVATEKEY", "privateKey"]],
+    });
+    expect(errorMessage).eql(`=== Ambiguous GitHub configuration properties ===
+- clientId is defined in config as well as environment variable LIVEBUNDLE_GITHUB_CLIENTID
+=== Missing GitHub configuration properties ===
+- Missing privateKey in config. Either set it in config or as environment variable LIVEBUNDLE_GITHUB_PRIVATEKEY
+`);
+  });
+
+  it("should return expected error message [ambiguous property]", () => {
+    const errorMessage = getErrorMessage({
+      ambiguousConfigProps: [["LIVEBUNDLE_GITHUB_CLIENTID", "clientId"]],
+      missingConfigProps: [],
+    });
+    expect(errorMessage).eql(`=== Ambiguous GitHub configuration properties ===
+- clientId is defined in config as well as environment variable LIVEBUNDLE_GITHUB_CLIENTID
+`);
+  });
+
+  it("should return expected error message [missing property]", () => {
+    const errorMessage = getErrorMessage({
+      ambiguousConfigProps: [],
+      missingConfigProps: [["LIVEBUNDLE_GITHUB_PRIVATEKEY", "privateKey"]],
+    });
+    expect(errorMessage).eql(`=== Missing GitHub configuration properties ===
+- Missing privateKey in config. Either set it in config or as environment variable LIVEBUNDLE_GITHUB_PRIVATEKEY
+`);
+  });
+});


### PR DESCRIPTION
`livebundle-github-consumer` requires the following GitHub application configuration properties to properly operate :
- appIdentifier
- clientId
- clientSecret
- privateKey

These configuration properties can be defined in the `livebundle-github-consumer` yaml configuration file.

That being said, this is not ideal, given that these values should be considered sensitive _(secrets)_. mixing them in the configuration file along with all other non sensitive config properties can be problematic. Moving these properties in a different configuration file would make things more complex.

This PR adds support for providing these configuration properties via environment variables. This also plays nicely with Kubernetes secrets that are commonly injected as environment variables. The associated environment variables are the following :

- LIVEBUNDLE_GITHUB_APP_APPIDENTIFIER
- LIVEBUNDLE_GITHUB_APP_CLIENTID
- LIVEBUNDLE_GITHUB_APP_CLIENTSECRET
- LIVEBUNDLE_GITHUB_APP_PRIVATEKEY

Each of these config properties can only be defined in one location to avoid any ambiguity. Either in the yaml config or as an environment variable. If some properties are defined in both locations, `livebundle-github-consumer` will fail at startup with a clear error message. If any of the properties are missing (not defined in yaml supplied config nor as an environment variable), the service will also fail at startup with a clear error message.
