### PR TITLE
Do not upload assets that are already in storage

### DIFF
--- a/packages/livebundle-sdk/src/types/index.ts
+++ b/packages/livebundle-sdk/src/types/index.ts
@@ -60,6 +60,8 @@ export interface Storage {
       contentType?: string;
     },
   ): Promise<string>;
+  hasFile(filePath: string): Promise<boolean>;
+  downloadFile(filePath: string): Promise<Buffer>;
   readonly baseUrl: string;
 }
 export interface Notifier {

--- a/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
+++ b/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
@@ -83,6 +83,12 @@ describe("LiveBundleImpl", () => {
 });
 
 class FakeStorage implements NamedStorage {
+  hasFile(filePath: string): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  downloadFile(filePath: string): Promise<Buffer> {
+    return Promise.resolve(Buffer.from("[]", "utf8"));
+  }
   name: string;
   store(
     content: string,

--- a/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
+++ b/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
@@ -2,11 +2,16 @@ import "mocha";
 import { ModuleLoaderImpl } from "../src";
 import fs from "fs-extra";
 import path from "path";
-import { UploaderImpl, Bundler, Storage } from "livebundle-sdk";
-import sinon from "sinon";
+import { Storage } from "livebundle-sdk";
 import { expect } from "chai";
 
 class FakeStorage implements Storage {
+  hasFile(filePath: string): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+  downloadFile(filePath: string): Promise<Buffer> {
+    throw new Error("Method not implemented.");
+  }
   store(
     content: string,
     contentLength: number,

--- a/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
+++ b/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
@@ -42,6 +42,26 @@ export class AzureStorageImpl implements Storage {
       );
   }
 
+  hasFile(filePath: string): Promise<boolean> {
+    log(`hasFile(filePath: ${filePath})`);
+
+    const containerClient = this.blobServiceClient.getContainerClient(
+      this.config.container,
+    );
+    const blockBlobClient = containerClient.getBlockBlobClient(filePath);
+    return blockBlobClient.exists();
+  }
+
+  downloadFile(filePath: string): Promise<Buffer> {
+    log(`downloadFile(filePath: ${filePath})`);
+
+    const containerClient = this.blobServiceClient.getContainerClient(
+      this.config.container,
+    );
+    const blockBlobClient = containerClient.getBlockBlobClient(filePath);
+    return blockBlobClient.downloadToBuffer();
+  }
+
   public static async create(
     azureConfig: AzureBlobStorageConfig,
   ): Promise<AzureStorageImpl> {

--- a/packages/livebundle-storage-fs/src/FsStorageImpl.ts
+++ b/packages/livebundle-storage-fs/src/FsStorageImpl.ts
@@ -28,6 +28,18 @@ export class FsStorageImpl implements Storage {
     fs.ensureDir(this.storageDir);
   }
 
+  hasFile(filePath: string): Promise<boolean> {
+    log(`hasFile(filePath: ${filePath})`);
+
+    return fs.pathExists(path.join(this.storageDir, filePath));
+  }
+
+  downloadFile(filePath: string): Promise<Buffer> {
+    log(`downloadFile(filePath: ${filePath})`);
+
+    return fs.readFile(path.join(this.storageDir, filePath));
+  }
+
   public static async create(config: FsStorageConfig): Promise<FsStorageImpl> {
     return new FsStorageImpl(config);
   }

--- a/packages/livebundle-storage-fs/test/FsStorageImpl.test.ts
+++ b/packages/livebundle-storage-fs/test/FsStorageImpl.test.ts
@@ -10,6 +10,21 @@ describe("FsStorageImpl", () => {
     storageDir: tmp.dirSync({ unsafeCleanup: true }).name,
   });
 
+  const writeTmpFile = async (content: string): Promise<string> => {
+    const tmpPath = tmp.dirSync({ unsafeCleanup: true }).name;
+    const tmpFilePath = path.join(tmpPath, "tmp.file");
+    await fs.writeFile(tmpFilePath, content, { encoding: "utf-8" });
+    return tmpFilePath;
+  };
+
+  describe("baseUrl getter", () => {
+    it("should return the root directory of the storage", () => {
+      const config = storageConfig();
+      const sut = new FsStorageImpl(config);
+      expect(sut.baseUrl).equal(config.storageDir);
+    });
+  });
+
   describe("create", () => {
     it("should return an instance of FsStorageImpl", async () => {
       const res = await FsStorageImpl.create(storageConfig());
@@ -28,13 +43,41 @@ describe("FsStorageImpl", () => {
 
   describe("storeFile", () => {
     it("should store the file in target file location", async () => {
-      const tmpPath = tmp.dirSync({ unsafeCleanup: true }).name;
-      const tmpFilePath = path.join(tmpPath, "tmp.file");
-      await fs.writeFile(tmpFilePath, "abcd", { encoding: "utf-8" });
+      const tmpFilePath = await writeTmpFile("foo");
       const config = storageConfig();
       const sut = new FsStorageImpl(config);
       await sut.storeFile(tmpFilePath, "test.file");
       expect(fs.existsSync(path.join(config.storageDir!, "test.file")));
+    });
+  });
+
+  describe("hasFile", () => {
+    it("should returrn true if the file exists", async () => {
+      const config = storageConfig();
+      const sut = new FsStorageImpl(config);
+      await fs.writeFile(path.join(config.storageDir!, "test.file"), "foo", {
+        encoding: "utf-8",
+      });
+      const result = await sut.hasFile("test.file");
+      expect(result).true;
+    });
+
+    it("should returrn false if the file does not exists", async () => {
+      const sut = new FsStorageImpl(storageConfig());
+      const result = await sut.hasFile("test.file");
+      expect(result).false;
+    });
+  });
+
+  describe("downloadFile", () => {
+    it("should return the downloaded file as a Buffer", async () => {
+      const config = storageConfig();
+      const sut = new FsStorageImpl(config);
+      await fs.writeFile(path.join(config.storageDir!, "test.file"), "foo", {
+        encoding: "utf-8",
+      });
+      const result = await sut.downloadFile("test.file");
+      expect(result.toString()).equal("foo");
     });
   });
 });


### PR DESCRIPTION
LiveBundle currently always uploads to the storage, all assets referenced in each bundle.

This PR adds an optimization, to avoid uploading assets that are already present in the storage, saving time, operations and bandwidth, ultimately reducing costs.

It just keeps a `metadata.json` file in the storage `assets` "directory", containing MD5 hashes of all the assets currently in storage. When time comes for LiveBundle to upload bundle assets, it will first retrieve this file, to know which assets currently exist in storage, and will only upload the ones that are not yet present in storage _(and will then upload an updated `asssets/metadata.json` file)._