### PR TITLE
Refactor configuration

### DIFF
--- a/packages/livebundle-bundler-metro/src/schemas/config.json
+++ b/packages/livebundle-bundler-metro/src/schemas/config.json
@@ -17,8 +17,10 @@
           "platform": {
             "enum": ["android", "ios"]
           }
-        }
+        },
+        "required": ["dev", "entry", "platform"]
       }
     }
-  }
+  },
+  "required": ["bundles"]
 }

--- a/packages/livebundle-notifier-github/src/schemas/config.json
+++ b/packages/livebundle-notifier-github/src/schemas/config.json
@@ -9,5 +9,6 @@
     "token": {
       "type": "string"
     }
-  }
+  },
+  "required": ["baseUrl", "token"]
 }

--- a/packages/livebundle-sdk/src/ModuleLoaderImpl.ts
+++ b/packages/livebundle-sdk/src/ModuleLoaderImpl.ts
@@ -95,13 +95,13 @@ export class ModuleLoaderImpl implements ModuleLoader {
         envVarToConfigKey: Module.envVarToConfigKey,
       }).config!;
     }
-    if (Module.defaultConfig) {
-      moduleConfig = await loadConfig<Record<string, unknown>>({
-        config: moduleConfig,
-        defaultConfig: Module.defaultConfig,
-        schema: Module.schema,
-      });
-    }
+
+    moduleConfig = await loadConfig<Record<string, unknown>>({
+      config: moduleConfig,
+      defaultConfig: Module.defaultConfig,
+      schema: Module.schema,
+    });
+
     return {
       Module,
       moduleConfig,

--- a/packages/livebundle-sdk/test/reconciliateConfig.test.ts
+++ b/packages/livebundle-sdk/test/reconciliateConfig.test.ts
@@ -38,7 +38,7 @@ describe("reconciliateConfig", () => {
     expect(res.config).deep.equal(finalConfig);
   });
 
-  it("should throw if property is missing from config and not set as env var", () => {
+  it("should not throw if property is missing from config and not set as env var", () => {
     expect(() =>
       reconciliateConfig({
         curConfig: {
@@ -47,7 +47,7 @@ describe("reconciliateConfig", () => {
         },
         envVarToConfigKey,
       }),
-    ).to.throw();
+    ).to.not.throw();
   });
 
   it("should throw if property is present in config and also set as env var", () => {
@@ -66,35 +66,12 @@ describe("reconciliateConfig", () => {
 });
 
 describe("getErrorMessage", () => {
-  it("should return the correct error message [ambiguous & missing props]", () => {
+  it("should return the correct error message [ambiguous props]", () => {
     const errorMessage = getErrorMessage({
       ambiguousConfigProps: [["LB_TEST_PROPA", "propA"]],
-      missingConfigProps: [["LB_TEST_PROPB", "propB"]],
     });
     expect(errorMessage).equal(`=== Ambiguous configuration properties ===
 - propA is defined in config as well as environment variable LB_TEST_PROPA
-=== Missing configuration properties ===
-- Missing 'propB' in config. Either set it in config or as environment variable LB_TEST_PROPB
-`);
-  });
-
-  it("should return the correct error message [ambiguous props only]", () => {
-    const errorMessage = getErrorMessage({
-      ambiguousConfigProps: [["LB_TEST_PROPA", "propA"]],
-      missingConfigProps: [],
-    });
-    expect(errorMessage).equal(`=== Ambiguous configuration properties ===
-- propA is defined in config as well as environment variable LB_TEST_PROPA
-`);
-  });
-
-  it("should return the correct error message [missing props only]", () => {
-    const errorMessage = getErrorMessage({
-      ambiguousConfigProps: [],
-      missingConfigProps: [["LB_TEST_PROPB", "propB"]],
-    });
-    expect(errorMessage).equal(`=== Missing configuration properties ===
-- Missing 'propB' in config. Either set it in config or as environment variable LB_TEST_PROPB
 `);
   });
 });

--- a/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
+++ b/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
@@ -2,6 +2,7 @@ import { BlobServiceClient } from "@azure/storage-blob";
 import debug from "debug";
 import { AzureBlobStorageConfig } from "./types";
 import { Storage } from "livebundle-sdk";
+import { configSchema } from "./schemas";
 
 const log = debug("livebundle-storage-impl:AzureStorageImpl");
 
@@ -21,6 +22,8 @@ export class AzureStorageImpl implements Storage {
     return `${this.baseUrl}/${p}${this.config.sasTokenReads ?? ""}`;
   }
 
+  public static readonly schema: Record<string, unknown> = configSchema;
+
   public static readonly envVarToConfigKey: Record<string, string> = {
     LB_STORAGE_AZURE_ACCOUNTURL: "accountUrl",
     LB_STORAGE_AZURE_CONTAINER: "container",
@@ -36,7 +39,7 @@ export class AzureStorageImpl implements Storage {
     this.blobServiceClient =
       blobServiceClient ??
       new BlobServiceClient(
-        `${this.accountUrl}${azureConfig.sasToken}`,
+        `${this.accountUrl}${azureConfig.sasToken ?? ""}`,
         undefined,
         azureConfig.options,
       );

--- a/packages/livebundle-storage-azure/src/schemas/config.json
+++ b/packages/livebundle-storage-azure/src/schemas/config.json
@@ -15,5 +15,6 @@
     "sasTokenReads": {
       "type": "string"
     }
-  }
+  },
+  "required": ["accountUrl", "container"]
 }

--- a/packages/livebundle-storage-fs/src/FsStorageImpl.ts
+++ b/packages/livebundle-storage-fs/src/FsStorageImpl.ts
@@ -15,6 +15,10 @@ export class FsStorageImpl implements Storage {
     return this.storageDir;
   }
 
+  public static readonly envVarToConfigKey: Record<string, string> = {
+    LB_STORAGE_FS_STORAGEDIR: "storageDir",
+  };
+
   public static readonly defaultConfig: Record<
     string,
     unknown

--- a/packages/livebundle/package.json
+++ b/packages/livebundle/package.json
@@ -28,6 +28,7 @@
     "livebundle-sdk": "^0.3.1",
     "livebundle-storage-azure": "^0.3.1",
     "livebundle-storage-fs": "^0.3.1",
+    "lodash": "^4.17.20",
     "node-emoji": "^1.10.0",
     "open": "^7.2.1",
     "ora": "^4.0.5",

--- a/packages/livebundle/src/index.ts
+++ b/packages/livebundle/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./program";
+export * from "./resolveConfigPath";
 export * from "./schemas";
 export * from "./types";

--- a/packages/livebundle/src/program.ts
+++ b/packages/livebundle/src/program.ts
@@ -6,6 +6,8 @@ import { configSchema } from "./schemas";
 import { Config } from "./types";
 import emoji from "node-emoji";
 import ora from "ora";
+import _ from "lodash";
+import { resolveConfigPath } from "./resolveConfigPath";
 
 const pJsonPath = path.resolve(__dirname, "..", "package.json");
 const pJson = fs.readJSONSync(pJsonPath);
@@ -28,8 +30,7 @@ export default function program({
       let conf;
       try {
         conf = await loadConfig<Config>({
-          configPath: config,
-          defaultFileName: "livebundle",
+          configPath: config ?? resolveConfigPath(),
           schema: configSchema,
         });
       } catch (e) {
@@ -59,7 +60,6 @@ export default function program({
       try {
         conf = await loadConfig<Config>({
           configPath: config,
-          defaultFileName: "livebundle",
           schema: configSchema,
         });
       } catch (e) {

--- a/packages/livebundle/src/resolveConfigPath.ts
+++ b/packages/livebundle/src/resolveConfigPath.ts
@@ -1,0 +1,16 @@
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
+
+export function resolveConfigPath(): string | undefined {
+  const paths = [
+    path.resolve("livebundle.yml"),
+    path.resolve("livebundle.yaml"),
+    "/etc/livebundle/livebundle.yml",
+    "/etc/livebundle/livebundle.yaml",
+    `${process.env.HOME}/livebundle.yml`,
+    `${process.env.HOME}/livebundle.yaml`,
+  ];
+
+  return _.find(paths, (p) => fs.pathExistsSync(p));
+}

--- a/packages/livebundle/test/resolveConfigPath.test.ts
+++ b/packages/livebundle/test/resolveConfigPath.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai";
+import fs from "fs-extra";
+import "mocha";
+import path from "path";
+import sinon from "sinon";
+import program from "../src/program";
+import { LiveBundleConfig, LiveBundle } from "livebundle-sdk";
+import tmp from "tmp";
+import { resolveConfigPath } from "../src";
+
+describe("resolveConfigPath", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  [
+    path.resolve("livebundle.yml"),
+    path.resolve("livebundle.yaml"),
+    "/etc/livebundle/livebundle.yml",
+    "/etc/livebundle/livebundle.yaml",
+    `${process.env.HOME}/livebundle.yml`,
+    `${process.env.HOME}/livebundle.yaml`,
+  ].forEach((p) =>
+    it(`should try each config path and return it if it exist [${p}]`, () => {
+      sandbox.stub(fs, "pathExistsSync").withArgs(p).returns(true);
+      const res = resolveConfigPath();
+      expect(res).equals(p);
+    }),
+  );
+
+  it("should return undefined if no config path was found", () => {
+    sandbox.stub(fs, "pathExistsSync").returns(false);
+    const res = resolveConfigPath();
+    expect(res).undefined;
+  });
+});


### PR DESCRIPTION
Quick refactoring around configuration.

This PR improves configuration mechanism as follow :

- Prior to this change, any module configuration property mapped to an env var *(via envVarToConfigKey)* was considered as mandatory, no matter what. This behavior is changed by this PR. The source of truth for mandatory vs optional configuration properties is now coming from the module configuration JSON schema.

- Prior to this change, only the loaded resolved configuration was validated against the schema. This wasn't proper as some required values might have not been explicitly specified in configuration, but coming from default config. The configuration is now validated against JSON schema only once it is merged with the default schema *(if any)*.

- Prior to this change, livebunde-sdk loadConfig method was in some way tightly coupled with the livebundle CLI module as it was looking for a configuration file for the CLI in some default locations. This PR removes this tight coupling by relocation config file location resolution in the CLI module itself.