### PR TITLE
Rename an Azure Storage env var

### DIFF
--- a/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
+++ b/packages/livebundle-storage-azure/src/AzureStorageImpl.ts
@@ -28,7 +28,7 @@ export class AzureStorageImpl implements Storage {
     LB_STORAGE_AZURE_ACCOUNTURL: "accountUrl",
     LB_STORAGE_AZURE_CONTAINER: "container",
     LB_STORAGE_AZURE_SASTOKEN: "sasToken",
-    LB_STORAGE_AZURE_SASTOKENDOWNLOAD: "sasTokenReads",
+    LB_STORAGE_AZURE_SASTOKENREADS: "sasTokenReads",
   };
 
   public constructor(

--- a/packages/livebundle/config/default.yaml
+++ b/packages/livebundle/config/default.yaml
@@ -39,14 +39,16 @@ storage:
   # YAML configuration, to limit exposure
   # especially for the SAS token.
   # The corresponding env variables are :
-  # accountUrl  => LB_STORAGE_AZURE_ACCOUNTURL
-  # container   => LB_STORAGE_AZURE_CONTAINER
-  # sasToken    => LB_STORAGE_AZURE_SASTOKEN
+  # accountUrl    => LB_STORAGE_AZURE_ACCOUNTURL
+  # container     => LB_STORAGE_AZURE_CONTAINER
+  # sasToken      => LB_STORAGE_AZURE_SASTOKEN
+  # sasTokenReads => LB_STORAGE_AZURE_SASTOKENREADS
   #
   #azure:
   #  accountUrl: <azure-store-account-url>
   #  container: <azure-container-name>
-  #  sasToken: <azure-shared-access-signature-token>
+  #  sasToken: <azure-shared-access-signature-token-for-uploads>
+  #  sasTokenReads: <azure-sastoken-for-reads>
 
 #
 # Generators configuration


### PR DESCRIPTION
`LB_STORAGE_AZURE_SASTOKENDOWNLOAD` => `LB_STORAGE_AZURE_SASTOKENREADS` to make it aligned on underlying config property name *(sasTokenReads)*

Also add this property to default `livebundle init` generated configuration *(was missing from this file)*