### PR TITLE
Add new cwd option to upload command

### DIFF
--- a/packages/livebundle/src/program.ts
+++ b/packages/livebundle/src/program.ts
@@ -6,7 +6,6 @@ import { configSchema } from "./schemas";
 import { Config } from "./types";
 import emoji from "node-emoji";
 import ora from "ora";
-import _ from "lodash";
 import { resolveConfigPath } from "./resolveConfigPath";
 
 const pJsonPath = path.resolve(__dirname, "..", "package.json");
@@ -25,10 +24,14 @@ export default function program({
   uploadCommand
     .name("upload")
     .option("--config <string>", "Path to config file")
+    .option("--cwd <string>", "Set current working directory")
     .description("bundle and upload resulting bundles")
-    .action(async ({ config }: { config?: string }) => {
+    .action(async ({ config, cwd }: { config?: string; cwd?: string }) => {
       let conf;
       try {
+        if (cwd) {
+          process.chdir(cwd);
+        }
         conf = await loadConfig<Config>({
           configPath: config ?? resolveConfigPath(),
           schema: configSchema,


### PR DESCRIPTION
Add new `--cwd` option to `upload` command.
This new option can be used to set a different current working directory for the `upload` command to work from _(instead of directory from which the command is run)_
This will be of use for LiveBundle development, but also in some scenarios where the `upload` command needs to be run from a different directory _(for example when using LiveBundle with Electrode Native where the `upload` command will need to be run from the composite directory)_