### PR TITLE
Log an error message if configuration file is missing

### DIFF
--- a/packages/livebundle/src/program.ts
+++ b/packages/livebundle/src/program.ts
@@ -32,8 +32,14 @@ export default function program({
         if (cwd) {
           process.chdir(cwd);
         }
+        const resolvedConfigPath = resolveConfigPath();
+        if (!config && !resolvedConfigPath) {
+          return console.error(`No LiveBundle configuration file found.
+- To create a new configuration file you can use 'livebundle init' command
+- To use an existing configuration file from a specific location you can use the '--config' option`);
+        }
         conf = await loadConfig<Config>({
-          configPath: config ?? resolveConfigPath(),
+          configPath: config ?? resolvedConfigPath,
           schema: configSchema,
         });
       } catch (e) {

--- a/packages/livebundle/test/program.test.ts
+++ b/packages/livebundle/test/program.test.ts
@@ -77,6 +77,13 @@ describe("program", () => {
       sinon.assert.calledOnce(consoleErrorStub);
     });
 
+    it("should log an error to the console if the config is missing", async () => {
+      const consoleErrorStub = sandbox.stub(console, "error");
+      const sut = program({ livebundle: new FakeLiveBundle() }).exitOverride();
+      await sut.parseAsync(["node", "livebundle", "upload"]);
+      sinon.assert.calledOnce(consoleErrorStub);
+    });
+
     it("should not throw if the livebundle upload fails", async () => {
       const lbStub = sandbox.createStubInstance(FakeLiveBundle);
       lbStub.upload.rejects("boom");


### PR DESCRIPTION
Log an informative error message and exit in case configuration file is missing when using `upload` command.
Otherwise, the command would try to work with an undefined configuration file, which would throw a cryptic error down the line.