### PR TITLE
Enable auto attach in workspace configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "debug.javascript.autoAttachFilter": "onlyWithFlag"
+}


### PR DESCRIPTION
Enables auto attach mode in workspace settings so that developers don't have to enable it manually for debugging.