### PR TITLE
Update Generator interface

### DIFF
--- a/packages/livebundle-generator-deeplink/src/types/index.ts
+++ b/packages/livebundle-generator-deeplink/src/types/index.ts
@@ -1,3 +1,3 @@
-export interface DeepLinkGeneratorResult {
+export interface DeepLinkGeneratorResult extends Record<string, unknown> {
   deepLinkUrl: string;
 }

--- a/packages/livebundle-generator-qrcode/src/types/index.ts
+++ b/packages/livebundle-generator-qrcode/src/types/index.ts
@@ -10,7 +10,7 @@ export interface QrCodeGeneratorImageConfig {
   path: string;
 }
 
-export interface QrCodeGeneratorResult {
+export interface QrCodeGeneratorResult extends Record<string, unknown> {
   localImagePath: string;
   remoteImagePath: string;
   terminalImage: string;

--- a/packages/livebundle-sdk/src/types/index.ts
+++ b/packages/livebundle-sdk/src/types/index.ts
@@ -40,7 +40,7 @@ export interface Generator {
   }: {
     id: string;
     type: LiveBundleContentType;
-  }): Promise<any>;
+  }): Promise<Record<string, unknown>>;
 }
 
 export interface Uploader {


### PR DESCRIPTION
Instead of returning `any` from the `generate` method, return `Record<string, unknown>` instead.
Done because we are using `noImplicitAny` and also because the output of generators is fed directly to the `notify` method of notifiers plugins, and the type declaration of this input parameter is `Record<string, Record<string, unknown>>` so this makes it more explicit. Will probably switch to more meaningful type aliases in further PR.