### PR TITLE
Rename PluginLoader methods

### DIFF
--- a/packages/livebundle-sdk/src/LiveBundleImpl.ts
+++ b/packages/livebundle-sdk/src/LiveBundleImpl.ts
@@ -22,7 +22,7 @@ export class LiveBundleImpl implements LiveBundle {
       generators,
       notifiers,
       uploader,
-    } = await this.moduleLoader.loadModules(config);
+    } = await this.moduleLoader.loadAllPlugins(config);
 
     const bundles: LocalBundle[] = await bundler.bundle();
 
@@ -53,7 +53,7 @@ export class LiveBundleImpl implements LiveBundle {
       generators,
       notifiers,
       storage,
-    } = await this.moduleLoader.loadModules(config);
+    } = await this.moduleLoader.loadAllPlugins(config);
 
     const metadata = JSON.stringify({
       host: `${ip.address()}:8081`,

--- a/packages/livebundle-sdk/src/PluginLoaderImpl.ts
+++ b/packages/livebundle-sdk/src/PluginLoaderImpl.ts
@@ -14,7 +14,7 @@ import debug from "debug";
 const log = debug("livebundle-sdk:PluginLoaderImpl");
 
 export class PluginLoaderImpl implements PluginLoader {
-  public async loadLiveBundleBundlerModule(
+  public async loadBundlerPlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedBundler> {
@@ -28,12 +28,12 @@ export class PluginLoaderImpl implements PluginLoader {
     return module;
   }
 
-  public async loadLiveBundleGeneratorModule(
+  public async loadGeneratorPlugin(
     name: string,
     config: Record<string, unknown>,
     storage: Storage,
   ): Promise<NamedGenerator> {
-    log(`loadLiveBundleGeneratorModule(name: ${name})`);
+    log(`loadGeneratorPlugin(name: ${name})`);
     const { Module, moduleConfig } = await this.loadLiveBundleModule(
       "generator",
       name,
@@ -44,7 +44,7 @@ export class PluginLoaderImpl implements PluginLoader {
     return module;
   }
 
-  public async loadLiveBundleNotifierModule(
+  public async loadNotifierPlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedNotifier> {
@@ -58,7 +58,7 @@ export class PluginLoaderImpl implements PluginLoader {
     return module;
   }
 
-  public async loadLiveBundleStorageModule(
+  public async loadStoragePlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedStorage> {
@@ -108,7 +108,7 @@ export class PluginLoaderImpl implements PluginLoader {
     };
   }
 
-  public async loadModules(
+  public async loadAllPlugins(
     config: LiveBundleConfig,
   ): Promise<{
     bundler: NamedBundler;
@@ -122,14 +122,14 @@ export class PluginLoaderImpl implements PluginLoader {
     const generatorModulesNames = Object.keys(config.generators);
     const notifierModulesNames = Object.keys(config.notifiers);
 
-    const storage: NamedStorage = await this.loadLiveBundleStorageModule(
+    const storage: NamedStorage = await this.loadStoragePlugin(
       storageModuleName,
       config.storage[storageModuleName] as Record<string, unknown>,
     );
     storage.name = storageModuleName;
     const uploader = new UploaderImpl(storage);
 
-    const bundler: NamedBundler = await this.loadLiveBundleBundlerModule(
+    const bundler: NamedBundler = await this.loadBundlerPlugin(
       bundlerModuleName,
       config.bundler[bundlerModuleName] as Record<string, unknown>,
     );
@@ -137,7 +137,7 @@ export class PluginLoaderImpl implements PluginLoader {
 
     const generators: NamedGenerator[] = [];
     for (const generatorModuleName of generatorModulesNames) {
-      const generator = await this.loadLiveBundleGeneratorModule(
+      const generator = await this.loadGeneratorPlugin(
         generatorModuleName,
         config.generators[generatorModuleName] as Record<string, unknown>,
         storage,
@@ -149,7 +149,7 @@ export class PluginLoaderImpl implements PluginLoader {
 
     const notifiers: NamedNotifier[] = [];
     for (const notifierModuleName of notifierModulesNames) {
-      const notifier = await this.loadLiveBundleNotifierModule(
+      const notifier = await this.loadNotifierPlugin(
         notifierModuleName,
         config.notifiers[notifierModuleName] as Record<string, unknown>,
       );

--- a/packages/livebundle-sdk/src/types/index.ts
+++ b/packages/livebundle-sdk/src/types/index.ts
@@ -141,24 +141,24 @@ export interface ReactNativeAsset {
 }
 
 export interface PluginLoader {
-  loadLiveBundleBundlerModule(
+  loadBundlerPlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedBundler>;
-  loadLiveBundleGeneratorModule(
+  loadGeneratorPlugin(
     name: string,
     config: Record<string, unknown>,
     storage: Storage,
   ): Promise<NamedGenerator>;
-  loadLiveBundleNotifierModule(
+  loadNotifierPlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedNotifier>;
-  loadLiveBundleStorageModule(
+  loadStoragePlugin(
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedStorage>;
-  loadModules(
+  loadAllPlugins(
     config: LiveBundleConfig,
   ): Promise<{
     bundler: NamedBundler;

--- a/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
+++ b/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
@@ -28,7 +28,7 @@ describe("LiveBundleImpl", () => {
   describe("upload", () => {
     it("should go through", async () => {
       const moduleLoaderStub = sandbox.createStubInstance(PluginLoaderImpl);
-      moduleLoaderStub.loadModules.resolves({
+      moduleLoaderStub.loadAllPlugins.resolves({
         bundler: new FakeBundler(),
         storage: new FakeStorage(),
         uploader: new FakeUploader(),
@@ -56,7 +56,7 @@ describe("LiveBundleImpl", () => {
   describe("live", () => {
     it("should go through", async () => {
       const moduleLoaderStub = sandbox.createStubInstance(PluginLoaderImpl);
-      moduleLoaderStub.loadModules.resolves({
+      moduleLoaderStub.loadAllPlugins.resolves({
         bundler: new FakeBundler(),
         storage: new FakeStorage(),
         uploader: new FakeUploader(),

--- a/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
+++ b/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
@@ -30,10 +30,10 @@ class FakeStorage implements Storage {
 }
 
 describe("PluginLoaderImpl", () => {
-  describe("loadLiveBundleBundlerModule", () => {
+  describe("loadBundlerPlugin", () => {
     it("should load the bundler module", async () => {
       const sut = new PluginLoaderImpl();
-      const res = await sut.loadLiveBundleBundlerModule(
+      const res = await sut.loadBundlerPlugin(
         "metro",
         await fs.readJSON(
           path.join(
@@ -46,10 +46,10 @@ describe("PluginLoaderImpl", () => {
     });
   });
 
-  describe("loadLiveBundleGeneratorModule", () => {
+  describe("loadGeneratorPlugin", () => {
     it("should load the generator module", async () => {
       const sut = new PluginLoaderImpl();
-      const res = await sut.loadLiveBundleGeneratorModule(
+      const res = await sut.loadGeneratorPlugin(
         "deeplink",
         {},
         new FakeStorage(),
@@ -58,10 +58,10 @@ describe("PluginLoaderImpl", () => {
     });
   });
 
-  describe("loadLiveBundleNotifierModule", () => {
+  describe("loadNotifierPlugin", () => {
     it("should load the notifier module", async () => {
       const sut = new PluginLoaderImpl();
-      const res = await sut.loadLiveBundleNotifierModule("github", {
+      const res = await sut.loadNotifierPlugin("github", {
         token: "abcd",
         baseUrl: "https://foo",
       });
@@ -69,18 +69,18 @@ describe("PluginLoaderImpl", () => {
     });
   });
 
-  describe("loadLiveBundleStorageModule", () => {
+  describe("loadStoragePlugin", () => {
     it("should load the storage module", async () => {
       const sut = new PluginLoaderImpl();
-      const res = await sut.loadLiveBundleStorageModule("fs", {});
+      const res = await sut.loadStoragePlugin("fs", {});
       expect(res).not.undefined;
     });
   });
 
-  describe("loadModules", () => {
+  describe("loadAllPlugins", () => {
     it("should load the modules declared in configuration", async () => {
       const sut = new PluginLoaderImpl();
-      const res = await sut.loadModules({
+      const res = await sut.loadAllPlugins({
         bundler: {
           metro: null,
         },


### PR DESCRIPTION
`ModuleLoader` was renamed to `PluginLoader` recently.
However the methods of this interface were not renamed adequately. 