### PR TITLE
Rename plugin implementation classes

### DIFF
--- a/packages/livebundle-bundler-metro/src/MetroBundlerPlugin.ts
+++ b/packages/livebundle-bundler-metro/src/MetroBundlerPlugin.ts
@@ -7,9 +7,9 @@ import path from "path";
 import cp from "child_process";
 import { BundleAssetsResolverImpl } from "./BundleAssetsResolverImpl";
 
-const log = debug("livebundle-bundler-metro:MetroBundlerImpl");
+const log = debug("livebundle-bundler-metro:MetroBundlerPlugin");
 
-export class MetroBundlerImpl implements BundlerPlugin {
+export class MetroBundlerPlugin implements BundlerPlugin {
   private readonly spawn;
   private readonly bundleAssetsResolver;
 
@@ -29,8 +29,8 @@ export class MetroBundlerImpl implements BundlerPlugin {
 
   public static async create(
     config: MetroBundlerConfig,
-  ): Promise<MetroBundlerImpl> {
-    return new MetroBundlerImpl(config);
+  ): Promise<MetroBundlerPlugin> {
+    return new MetroBundlerPlugin(config);
   }
 
   public static readonly defaultConfig: Record<

--- a/packages/livebundle-bundler-metro/src/index.ts
+++ b/packages/livebundle-bundler-metro/src/index.ts
@@ -1,5 +1,5 @@
-import { MetroBundlerImpl } from "./MetroBundlerImpl";
+import { MetroBundlerPlugin } from "./MetroBundlerPlugin";
 export * from "./types";
 export * from "./schemas";
 export * from "./BundleAssetsResolverImpl";
-export default MetroBundlerImpl;
+export default MetroBundlerPlugin;

--- a/packages/livebundle-bundler-metro/test/MetroBundlerPlugin.test.ts
+++ b/packages/livebundle-bundler-metro/test/MetroBundlerPlugin.test.ts
@@ -1,5 +1,5 @@
 import "mocha";
-import MetroBundlerImpl, {
+import MetroBundlerPlugin, {
   BundleAssetsResolver,
   MetroBundlerConfig,
 } from "../src";
@@ -14,7 +14,7 @@ class NullBundleAssetsResolver implements BundleAssetsResolver {
   }
 }
 
-describe("MetroBundlerImpl", () => {
+describe("MetroBundlerPlugin", () => {
   const sandbox = sinon.createSandbox();
 
   const bundlerConfig: MetroBundlerConfig = {
@@ -26,9 +26,9 @@ describe("MetroBundlerImpl", () => {
   });
 
   describe("create", () => {
-    it("should return an instance of MetroBundlerImpl", async () => {
-      const res = await MetroBundlerImpl.create(bundlerConfig);
-      expect(res).instanceOf(MetroBundlerImpl);
+    it("should return an instance of MetroBundlerPlugin", async () => {
+      const res = await MetroBundlerPlugin.create(bundlerConfig);
+      expect(res).instanceOf(MetroBundlerPlugin);
     });
   });
 
@@ -60,7 +60,7 @@ describe("MetroBundlerImpl", () => {
 
     it("should go through", async () => {
       const spawn = sandbox.stub().returns(spawnRes);
-      const sut = new MetroBundlerImpl(bundlerConfig, {
+      const sut = new MetroBundlerPlugin(bundlerConfig, {
         bundleAssetsResolver: new NullBundleAssetsResolver(),
         spawn,
       });
@@ -71,7 +71,7 @@ describe("MetroBundlerImpl", () => {
       const spawn = sandbox
         .stub()
         .returns({ ...spawnRes, on: onCloseEvent(1) });
-      const sut = new MetroBundlerImpl(bundlerConfig, {
+      const sut = new MetroBundlerPlugin(bundlerConfig, {
         bundleAssetsResolver: new NullBundleAssetsResolver(),
         spawn,
       });

--- a/packages/livebundle-generator-deeplink/src/DeepLinkGeneratorPlugin.ts
+++ b/packages/livebundle-generator-deeplink/src/DeepLinkGeneratorPlugin.ts
@@ -2,11 +2,11 @@ import debug from "debug";
 import { DeepLinkGeneratorResult } from "./types";
 import { LiveBundleContentType, GeneratorPlugin } from "livebundle-sdk";
 
-const log = debug("livebundle-generator-deeplink:DeepLinkGeneratorImpl");
+const log = debug("livebundle-generator-deeplink:DeepLinkGeneratorPlugin");
 
-export class DeepLinkGeneratorImpl implements GeneratorPlugin {
-  public static async create(): Promise<DeepLinkGeneratorImpl> {
-    return new DeepLinkGeneratorImpl();
+export class DeepLinkGeneratorPlugin implements GeneratorPlugin {
+  public static async create(): Promise<DeepLinkGeneratorPlugin> {
+    return new DeepLinkGeneratorPlugin();
   }
 
   async generate({

--- a/packages/livebundle-generator-deeplink/src/index.ts
+++ b/packages/livebundle-generator-deeplink/src/index.ts
@@ -1,3 +1,3 @@
-import { DeepLinkGeneratorImpl } from "./DeepLinkGeneratorImpl";
+import { DeepLinkGeneratorPlugin } from "./DeepLinkGeneratorPlugin";
 export * from "./types";
-export default DeepLinkGeneratorImpl;
+export default DeepLinkGeneratorPlugin;

--- a/packages/livebundle-generator-deeplink/test/DeepLinkGeneratorPlugin.test.ts
+++ b/packages/livebundle-generator-deeplink/test/DeepLinkGeneratorPlugin.test.ts
@@ -1,20 +1,20 @@
 import { expect } from "chai";
 import "mocha";
-import DeepLinkGeneratorImpl from "../src";
+import DeepLinkGeneratorPlugin from "../src";
 import { v4 as uuidv4 } from "uuid";
 import { LiveBundleContentType } from "livebundle-sdk";
 
-describe("DeepLinkGeneratorImpl", () => {
+describe("DeepLinkGeneratorPlugin", () => {
   describe("create", () => {
-    it("should return an instance of DeepLinkGeneratorImpl", async () => {
-      const res = await DeepLinkGeneratorImpl.create();
-      expect(res).instanceOf(DeepLinkGeneratorImpl);
+    it("should return an instance of DeepLinkGeneratorPlugin", async () => {
+      const res = await DeepLinkGeneratorPlugin.create();
+      expect(res).instanceOf(DeepLinkGeneratorPlugin);
     });
   });
 
   describe("generate", () => {
     it("should generate a LiveBundle package DeepLink", async () => {
-      const sut = new DeepLinkGeneratorImpl();
+      const sut = new DeepLinkGeneratorPlugin();
       const id = uuidv4();
       const result = await sut.generate({
         id,
@@ -24,7 +24,7 @@ describe("DeepLinkGeneratorImpl", () => {
     });
 
     it("should generate a LiveBundle session DeepLink", async () => {
-      const sut = new DeepLinkGeneratorImpl();
+      const sut = new DeepLinkGeneratorPlugin();
       const id = uuidv4();
       const result = await sut.generate({
         id,

--- a/packages/livebundle-generator-qrcode/src/QRCodeGeneratorPlugin.ts
+++ b/packages/livebundle-generator-qrcode/src/QRCodeGeneratorPlugin.ts
@@ -9,9 +9,9 @@ import { configSchema } from "./schemas";
 import path from "path";
 import qrcode from "qrcode";
 
-const log = debug("livebundle-generator-qrcode:QRCodeGeneratorImpl");
+const log = debug("livebundle-generator-qrcode:QRCodeGeneratorPlugin");
 
-export class QRCodeGeneratorImpl implements GeneratorPlugin {
+export class QRCodeGeneratorPlugin implements GeneratorPlugin {
   public constructor(
     private readonly config: QrCodeGeneratorConfig,
     private readonly storage: StoragePlugin,
@@ -27,8 +27,8 @@ export class QRCodeGeneratorImpl implements GeneratorPlugin {
   public static async create(
     config: QrCodeGeneratorConfig,
     storage: StoragePlugin,
-  ): Promise<QRCodeGeneratorImpl> {
-    return new QRCodeGeneratorImpl(config, storage);
+  ): Promise<QRCodeGeneratorPlugin> {
+    return new QRCodeGeneratorPlugin(config, storage);
   }
 
   async generate({

--- a/packages/livebundle-generator-qrcode/src/index.ts
+++ b/packages/livebundle-generator-qrcode/src/index.ts
@@ -1,4 +1,4 @@
-import { QRCodeGeneratorImpl } from "./QRCodeGeneratorImpl";
+import { QRCodeGeneratorPlugin } from "./QRCodeGeneratorPlugin";
 export * from "./types";
 export * from "./schemas";
-export default QRCodeGeneratorImpl;
+export default QRCodeGeneratorPlugin;

--- a/packages/livebundle-generator-qrcode/test/QRCodeGeneratorPlugin.test.ts
+++ b/packages/livebundle-generator-qrcode/test/QRCodeGeneratorPlugin.test.ts
@@ -1,14 +1,14 @@
 import { expect } from "chai";
 import "mocha";
-import QRCodeGeneratorImpl, { QrCodeGeneratorConfig } from "../src";
+import QRCodeGeneratorPlugin, { QrCodeGeneratorConfig } from "../src";
 import { v4 as uuidv4 } from "uuid";
 import { LiveBundleContentType } from "livebundle-sdk";
-import FsStorageImpl from "livebundle-storage-fs";
+import FsStoragePlugin from "livebundle-storage-fs";
 import tmp from "tmp";
 import path from "path";
 import fs from "fs-extra";
 
-describe("QRCodeGeneratorImpl", () => {
+describe("QRCodeGeneratorPlugin", () => {
   const generatorConfig = (): QrCodeGeneratorConfig => ({
     image: {
       margin: 1,
@@ -18,12 +18,12 @@ describe("QRCodeGeneratorImpl", () => {
   });
 
   describe("create", () => {
-    it("should return an instance of QRCodeGeneratorImpl", async () => {
-      const res = await QRCodeGeneratorImpl.create(
+    it("should return an instance of QRCodeGeneratorPlugin", async () => {
+      const res = await QRCodeGeneratorPlugin.create(
         generatorConfig(),
-        new FsStorageImpl({}),
+        new FsStoragePlugin({}),
       );
-      expect(res).instanceOf(QRCodeGeneratorImpl);
+      expect(res).instanceOf(QRCodeGeneratorPlugin);
     });
   });
 
@@ -31,8 +31,8 @@ describe("QRCodeGeneratorImpl", () => {
     [LiveBundleContentType.PACKAGE, LiveBundleContentType.SESSION].forEach(
       (lbContentType) => {
         it(`should generate a local QR code image [${lbContentType}]`, async () => {
-          const storage = new FsStorageImpl({});
-          const sut = new QRCodeGeneratorImpl(generatorConfig(), storage);
+          const storage = new FsStoragePlugin({});
+          const sut = new QRCodeGeneratorPlugin(generatorConfig(), storage);
           const res = await sut.generate({
             id: uuidv4(),
             type: lbContentType,
@@ -41,8 +41,8 @@ describe("QRCodeGeneratorImpl", () => {
         });
 
         it(`should generate a terminal friendly image [${lbContentType}]`, async () => {
-          const storage = new FsStorageImpl({});
-          const sut = new QRCodeGeneratorImpl(generatorConfig(), storage);
+          const storage = new FsStoragePlugin({});
+          const sut = new QRCodeGeneratorPlugin(generatorConfig(), storage);
           const res = await sut.generate({
             id: uuidv4(),
             type: lbContentType,
@@ -51,8 +51,8 @@ describe("QRCodeGeneratorImpl", () => {
         });
 
         it(`should store the image to the storage [${lbContentType}]`, async () => {
-          const storage = new FsStorageImpl({});
-          const sut = new QRCodeGeneratorImpl(generatorConfig(), storage);
+          const storage = new FsStoragePlugin({});
+          const sut = new QRCodeGeneratorPlugin(generatorConfig(), storage);
           const res = await sut.generate({
             id: uuidv4(),
             type: lbContentType,

--- a/packages/livebundle-notifier-github/src/GitHubNotifierPlugin.ts
+++ b/packages/livebundle-notifier-github/src/GitHubNotifierPlugin.ts
@@ -4,9 +4,9 @@ import { LiveBundleContentType, Package, NotifierPlugin } from "livebundle-sdk";
 import fs from "fs-extra";
 import { Octokit } from "@octokit/rest";
 
-const log = debug("livebundle-notifier-github:GitHubNotifierImpl");
+const log = debug("livebundle-notifier-github:GitHubNotifierPlugin");
 
-export class GitHubNotifierImpl implements NotifierPlugin {
+export class GitHubNotifierPlugin implements NotifierPlugin {
   private readonly octokit: Octokit;
 
   public constructor(
@@ -27,8 +27,8 @@ export class GitHubNotifierImpl implements NotifierPlugin {
 
   public static async create(
     config: GitHubNotifierConfig,
-  ): Promise<GitHubNotifierImpl> {
-    return new GitHubNotifierImpl(config);
+  ): Promise<GitHubNotifierPlugin> {
+    return new GitHubNotifierPlugin(config);
   }
 
   public async notify({

--- a/packages/livebundle-notifier-github/src/index.ts
+++ b/packages/livebundle-notifier-github/src/index.ts
@@ -1,4 +1,4 @@
-import { GitHubNotifierImpl } from "./GitHubNotifierImpl";
+import { GitHubNotifierPlugin } from "./GitHubNotifierPlugin";
 export * from "./types";
 export * from "./schemas";
-export default GitHubNotifierImpl;
+export default GitHubNotifierPlugin;

--- a/packages/livebundle-notifier-github/test/GitHubNotifierPlugin.test.ts
+++ b/packages/livebundle-notifier-github/test/GitHubNotifierPlugin.test.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { Octokit } from "@octokit/rest";
 import sinon from "sinon";
-import GitHubNotifierImpl, { GitHubNotifierConfig } from "../src";
+import GitHubNotifierPlugin, { GitHubNotifierConfig } from "../src";
 import { LiveBundleContentType, Package } from "livebundle-sdk";
 import { v4 as uuidv4 } from "uuid";
 import { expect } from "chai";
@@ -9,7 +9,7 @@ import tmp from "tmp";
 import fs from "fs-extra";
 import path from "path";
 
-describe("GitHubNotifierImpl", () => {
+describe("GitHubNotifierPlugin", () => {
   const sandbox = sinon.createSandbox();
 
   const stubs = {
@@ -67,15 +67,15 @@ describe("GitHubNotifierImpl", () => {
   });
 
   describe("create", () => {
-    it("should return an instance of GitHubNotifierImpl", async () => {
-      const res = await GitHubNotifierImpl.create(notifierConfig);
-      expect(res).instanceOf(GitHubNotifierImpl);
+    it("should return an instance of GitHubNotifierPlugin", async () => {
+      const res = await GitHubNotifierPlugin.create(notifierConfig);
+      expect(res).instanceOf(GitHubNotifierPlugin);
     });
   });
 
   describe("notify", () => {
     it("should not post a PR comment if LiveBundle content type is SESSION", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -92,7 +92,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should not post a PR comment if LB_NOTIFIER_GITHUB_PRURL and GITHUB_EVENT_PATH are missing", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       await sut.notify(notifyPayload);
@@ -100,7 +100,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should not post a PR comment if LB_NOTIFIER_GITHUB_PRURL is invalid", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -113,7 +113,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should work with LB_NOTIFIER_GITHUB_PRURL env var [GitHub action not used]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -126,7 +126,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should post proper PR comment [QRCode only]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -147,7 +147,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should post proper PR comment [DeepLink only]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -168,7 +168,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should post proper PR comment [LB_NOTIFIER_GITHUB_PRURL]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       try {
@@ -187,7 +187,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should work with GITHUB_EVENT_PATH env var [GitHub action]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       const tmpDir = tmp.dirSync({ unsafeCleanup: true }).name;
@@ -206,7 +206,7 @@ describe("GitHubNotifierImpl", () => {
     });
 
     it("should post proper PR comment [GITHUB_EVENT_PATH]", async () => {
-      const sut = new GitHubNotifierImpl(notifierConfig, {
+      const sut = new GitHubNotifierPlugin(notifierConfig, {
         octokit: stubs.octokit,
       });
       const tmpDir = tmp.dirSync({ unsafeCleanup: true }).name;

--- a/packages/livebundle-notifier-terminal/src/TerminalNotifierPlugin.ts
+++ b/packages/livebundle-notifier-terminal/src/TerminalNotifierPlugin.ts
@@ -2,15 +2,15 @@ import debug from "debug";
 import { LiveBundleContentType, Package, NotifierPlugin } from "livebundle-sdk";
 import chalk from "chalk";
 
-const log = debug("livebundle-notifier-terminal:TerminalNotifierImpl");
+const log = debug("livebundle-notifier-terminal:TerminalNotifierPlugin");
 
-export class TerminalNotifierImpl implements NotifierPlugin {
+export class TerminalNotifierPlugin implements NotifierPlugin {
   public constructor(
     private readonly logger: { log: (message?: string) => void } = console,
   ) {}
 
-  public static async create(): Promise<TerminalNotifierImpl> {
-    return new TerminalNotifierImpl();
+  public static async create(): Promise<TerminalNotifierPlugin> {
+    return new TerminalNotifierPlugin();
   }
 
   public async notify({

--- a/packages/livebundle-notifier-terminal/src/index.ts
+++ b/packages/livebundle-notifier-terminal/src/index.ts
@@ -1,2 +1,2 @@
-import { TerminalNotifierImpl } from "./TerminalNotifierImpl";
-export default TerminalNotifierImpl;
+import { TerminalNotifierPlugin } from "./TerminalNotifierPlugin";
+export default TerminalNotifierPlugin;

--- a/packages/livebundle-notifier-terminal/test/TerminalNotifierPlugin.test.ts
+++ b/packages/livebundle-notifier-terminal/test/TerminalNotifierPlugin.test.ts
@@ -1,11 +1,11 @@
 import "mocha";
-import TerminalNotifierImpl from "../src";
+import TerminalNotifierPlugin from "../src";
 import sinon from "sinon";
 import { v4 as uuidv4 } from "uuid";
 import { LiveBundleContentType } from "livebundle-sdk/src";
 import { expect } from "chai";
 
-describe("TerminalNotifierImpl", () => {
+describe("TerminalNotifierPlugin", () => {
   const sandbox = sinon.createSandbox();
 
   afterEach(() => {
@@ -13,16 +13,16 @@ describe("TerminalNotifierImpl", () => {
   });
 
   describe("create", () => {
-    it("should return an instance of TerminalNotifierImpl", async () => {
-      const res = await TerminalNotifierImpl.create();
-      expect(res).instanceOf(TerminalNotifierImpl);
+    it("should return an instance of TerminalNotifierPlugin", async () => {
+      const res = await TerminalNotifierPlugin.create();
+      expect(res).instanceOf(TerminalNotifierPlugin);
     });
   });
 
   describe("notify", () => {
     it("should log the QRCode if qrcode generator was used", async () => {
       const consoleStub = sandbox.stub(console);
-      const sut = new TerminalNotifierImpl(consoleStub);
+      const sut = new TerminalNotifierPlugin(consoleStub);
       const notifyPayload = {
         generators: { qrcode: { terminalImage: "fake-ascii-qrcode" } },
         pkg: { id: uuidv4(), bundles: [], timestamp: Date.now() },
@@ -37,7 +37,7 @@ describe("TerminalNotifierImpl", () => {
 
     it("should log the deep link if deeplink generator was used", async () => {
       const consoleStub = sandbox.stub(console);
-      const sut = new TerminalNotifierImpl(consoleStub);
+      const sut = new TerminalNotifierPlugin(consoleStub);
       const notifyPayload = {
         generators: { deeplink: { deepLinkUrl: "livebundle://fakeurl" } },
         pkg: { id: uuidv4(), bundles: [], timestamp: Date.now() },

--- a/packages/livebundle-notifier-viewer/src/ViewerNotifierPlugin.ts
+++ b/packages/livebundle-notifier-viewer/src/ViewerNotifierPlugin.ts
@@ -3,13 +3,13 @@ import debug from "debug";
 import { LiveBundleContentType, Package, NotifierPlugin } from "livebundle-sdk";
 import open from "open";
 
-const log = debug("livebundle-notifier-terminal:ViewerNotifierImpl");
+const log = debug("livebundle-notifier-terminal:ViewerNotifierPlugin");
 
-export class ViewerNotifierImpl implements NotifierPlugin {
+export class ViewerNotifierPlugin implements NotifierPlugin {
   public constructor(private readonly op: typeof open = open) {}
 
-  public static async create(): Promise<ViewerNotifierImpl> {
-    return new ViewerNotifierImpl();
+  public static async create(): Promise<ViewerNotifierPlugin> {
+    return new ViewerNotifierPlugin();
   }
 
   public async notify({

--- a/packages/livebundle-notifier-viewer/src/index.ts
+++ b/packages/livebundle-notifier-viewer/src/index.ts
@@ -1,2 +1,2 @@
-import { ViewerNotifierImpl } from "./ViewerNotifierImpl";
-export default ViewerNotifierImpl;
+import { ViewerNotifierPlugin } from "./ViewerNotifierPlugin";
+export default ViewerNotifierPlugin;

--- a/packages/livebundle-notifier-viewer/test/ViewerNotifierPlugin.test.ts
+++ b/packages/livebundle-notifier-viewer/test/ViewerNotifierPlugin.test.ts
@@ -1,15 +1,15 @@
 import "mocha";
-import ViewerNotifierImpl from "../src";
+import ViewerNotifierPlugin from "../src";
 import { v4 as uuidv4 } from "uuid";
 import { LiveBundleContentType } from "livebundle-sdk";
 import sinon from "sinon";
 import { expect } from "chai";
 
-describe("ViewerNotifierImpl", () => {
+describe("ViewerNotifierPlugin", () => {
   describe("create", () => {
-    it("should return an instance of ViewerNotifierImpl", async () => {
-      const res = await ViewerNotifierImpl.create();
-      expect(res).instanceOf(ViewerNotifierImpl);
+    it("should return an instance of ViewerNotifierPlugin", async () => {
+      const res = await ViewerNotifierPlugin.create();
+      expect(res).instanceOf(ViewerNotifierPlugin);
     });
   });
 
@@ -21,7 +21,7 @@ describe("ViewerNotifierImpl", () => {
         type: LiveBundleContentType.PACKAGE,
       };
       const openStub = sinon.stub();
-      const sut = new ViewerNotifierImpl(openStub);
+      const sut = new ViewerNotifierPlugin(openStub);
       await sut.notify(notifyPayload);
       sinon.assert.calledOnceWithExactly(
         openStub,
@@ -36,7 +36,7 @@ describe("ViewerNotifierImpl", () => {
         type: LiveBundleContentType.PACKAGE,
       };
       const openStub = sinon.stub();
-      const sut = new ViewerNotifierImpl(openStub);
+      const sut = new ViewerNotifierPlugin(openStub);
       await sut.notify(notifyPayload);
     });
   });

--- a/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
+++ b/packages/livebundle-sdk/test/ModuleLoaderImpl.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 import { StoragePlugin } from "livebundle-sdk";
 import { expect } from "chai";
 
-class FakeStorage implements StoragePlugin {
+class FakeStoragePlugin implements StoragePlugin {
   hasFile(filePath: string): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
@@ -52,7 +52,7 @@ describe("PluginLoaderImpl", () => {
       const res = await sut.loadGeneratorPlugin(
         "deeplink",
         {},
-        new FakeStorage(),
+        new FakeStoragePlugin(),
       );
       expect(res).not.undefined;
     });

--- a/packages/livebundle-sdk/test/UploaderImpl.test.ts
+++ b/packages/livebundle-sdk/test/UploaderImpl.test.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import { UploaderImpl } from "../src";
-import sinon, { stub } from "sinon";
+import sinon from "sinon";
 import {
   StoragePlugin,
   LocalBundle,
@@ -10,7 +10,7 @@ import {
 import { expect } from "chai";
 import path from "path";
 
-class FakeStorageImpl implements StoragePlugin {
+class FakeStoragePlugin implements StoragePlugin {
   hasFile(filePath: string): Promise<boolean> {
     return Promise.resolve(true);
   }
@@ -38,7 +38,7 @@ describe("UploaderImpl", () => {
   const sandbox = sinon.createSandbox();
 
   const stubs = {
-    storage: sandbox.createStubInstance(FakeStorageImpl),
+    storage: sandbox.createStubInstance(FakeStoragePlugin),
   };
 
   const assets: ReactNativeAsset[] = [

--- a/packages/livebundle-storage-azure/src/AzureStoragePlugin.ts
+++ b/packages/livebundle-storage-azure/src/AzureStoragePlugin.ts
@@ -4,9 +4,9 @@ import { AzureBlobStorageConfig } from "./types";
 import { StoragePlugin } from "livebundle-sdk";
 import { configSchema } from "./schemas";
 
-const log = debug("livebundle-storage-impl:AzureStorageImpl");
+const log = debug("livebundle-storage-impl:AzureStoragePlugin");
 
-export class AzureStorageImpl implements StoragePlugin {
+export class AzureStoragePlugin implements StoragePlugin {
   private readonly blobServiceClient: BlobServiceClient;
   private readonly config: AzureBlobStorageConfig;
 
@@ -67,8 +67,8 @@ export class AzureStorageImpl implements StoragePlugin {
 
   public static async create(
     azureConfig: AzureBlobStorageConfig,
-  ): Promise<AzureStorageImpl> {
-    return new AzureStorageImpl(azureConfig);
+  ): Promise<AzureStoragePlugin> {
+    return new AzureStoragePlugin(azureConfig);
   }
 
   async store(

--- a/packages/livebundle-storage-azure/src/index.ts
+++ b/packages/livebundle-storage-azure/src/index.ts
@@ -1,4 +1,4 @@
-import { AzureStorageImpl } from "./AzureStorageImpl";
+import { AzureStoragePlugin } from "./AzureStoragePlugin";
 export * from "./types";
 export * from "./schemas";
-export default AzureStorageImpl;
+export default AzureStoragePlugin;

--- a/packages/livebundle-storage-azure/test/AzureStoragePlugin.test.ts
+++ b/packages/livebundle-storage-azure/test/AzureStoragePlugin.test.ts
@@ -1,5 +1,5 @@
 import "mocha";
-import AzureStorageImpl, { AzureBlobStorageConfig } from "../src";
+import AzureStoragePlugin, { AzureBlobStorageConfig } from "../src";
 import { expect } from "chai";
 import sinon from "sinon";
 import { BlobServiceClient } from "@azure/storage-blob";
@@ -8,7 +8,7 @@ import tmp from "tmp";
 import fs from "fs-extra";
 import path from "path";
 
-describe("AzureStorageImpl", () => {
+describe("AzureStoragePlugin", () => {
   const sandbox = sinon.createSandbox();
   const stubs = {
     blobServiceClient: sinon.stub(BlobServiceClient) as any,
@@ -50,29 +50,29 @@ describe("AzureStorageImpl", () => {
   });
 
   describe("create", () => {
-    it("should return an instance of AzureStorageImpl", async () => {
-      const res = await AzureStorageImpl.create(storageConfig);
-      expect(res).instanceOf(AzureStorageImpl);
+    it("should return an instance of AzureStoragePlugin", async () => {
+      const res = await AzureStoragePlugin.create(storageConfig);
+      expect(res).instanceOf(AzureStoragePlugin);
     });
   });
 
   describe("get baseUrl", () => {
     it("should return the base url including container", () => {
-      const sut = new AzureStorageImpl(storageConfig);
+      const sut = new AzureStoragePlugin(storageConfig);
       expect(sut.baseUrl).equal(`${accountUrl}/${container}`);
     });
   });
 
   describe("getFilePathUrl", () => {
     it("should return the correct url [without reads sas token]", () => {
-      const sut = new AzureStorageImpl(storageConfig);
+      const sut = new AzureStoragePlugin(storageConfig);
       const p = "foo/file";
       expect(sut.getFilePathUrl(p)).equal(`${accountUrl}/${container}/${p}`);
     });
 
     it("should return the correct url [with reads sas token]", () => {
       const sasTokenReads = "?dummyToken";
-      const sut = new AzureStorageImpl({ ...storageConfig, sasTokenReads });
+      const sut = new AzureStoragePlugin({ ...storageConfig, sasTokenReads });
       const p = "foo/file";
       expect(sut.getFilePathUrl(p)).equal(
         `${accountUrl}/${container}/${p}${sasTokenReads}`,
@@ -83,7 +83,7 @@ describe("AzureStorageImpl", () => {
   describe("store", () => {
     it("should create a BlockBlobClient instance for the target path", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       await sut.store("foo", 3, targetPath);
@@ -92,7 +92,7 @@ describe("AzureStorageImpl", () => {
 
     it("should upload the content", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       await sut.store("foo", 3, targetPath);
@@ -101,7 +101,7 @@ describe("AzureStorageImpl", () => {
 
     it("should throw if it fails to upload content", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       stubs.upload.rejects();
@@ -116,7 +116,7 @@ describe("AzureStorageImpl", () => {
 
     it("should create a BlockBlobClient instance for the target path", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       await sut.storeFile(tmpFilePath, targetPath);
@@ -125,7 +125,7 @@ describe("AzureStorageImpl", () => {
 
     it("should upload the file [without content type]", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       await sut.storeFile(tmpFilePath, targetPath);
@@ -138,7 +138,7 @@ describe("AzureStorageImpl", () => {
 
     it("should upload the file [with content type]", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       await sut.storeFile(tmpFilePath, targetPath, {
@@ -153,7 +153,7 @@ describe("AzureStorageImpl", () => {
 
     it("should throw if it fails to upload content", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       stubs.uploadFile.rejects();
@@ -164,7 +164,7 @@ describe("AzureStorageImpl", () => {
   describe("hasFile", () => {
     it("should return true if the file exists", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       stubs.exists.resolves(true);
@@ -174,7 +174,7 @@ describe("AzureStorageImpl", () => {
 
     it("should return false if the file does not exists", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       stubs.exists.resolves(false);
@@ -186,7 +186,7 @@ describe("AzureStorageImpl", () => {
   describe("downloadFile", () => {
     it("should return the download file as a Buffer", async () => {
       const targetPath = "/target/file";
-      const sut = new AzureStorageImpl(storageConfig, {
+      const sut = new AzureStoragePlugin(storageConfig, {
         blobServiceClient: stubs.blobServiceClient,
       });
       stubs.downloadToBuffer.resolves(Buffer.from("foo", "utf8"));

--- a/packages/livebundle-storage-fs/src/FsStoragePlugin.ts
+++ b/packages/livebundle-storage-fs/src/FsStoragePlugin.ts
@@ -6,9 +6,9 @@ import tmp from "tmp";
 import fs from "fs-extra";
 import path from "path";
 
-const log = debug("livebundle-storage-fs:FsStorageImpl");
+const log = debug("livebundle-storage-fs:FsStoragePlugin");
 
-export class FsStorageImpl implements StoragePlugin {
+export class FsStoragePlugin implements StoragePlugin {
   private readonly storageDir: string;
 
   public get baseUrl(): string {
@@ -44,8 +44,10 @@ export class FsStorageImpl implements StoragePlugin {
     return fs.readFile(path.join(this.storageDir, filePath));
   }
 
-  public static async create(config: FsStorageConfig): Promise<FsStorageImpl> {
-    return new FsStorageImpl(config);
+  public static async create(
+    config: FsStorageConfig,
+  ): Promise<FsStoragePlugin> {
+    return new FsStoragePlugin(config);
   }
 
   async store(

--- a/packages/livebundle-storage-fs/src/index.ts
+++ b/packages/livebundle-storage-fs/src/index.ts
@@ -1,4 +1,4 @@
-import { FsStorageImpl } from "./FsStorageImpl";
+import { FsStoragePlugin } from "./FsStoragePlugin";
 export * from "./types";
 export * from "./schemas";
-export default FsStorageImpl;
+export default FsStoragePlugin;

--- a/packages/livebundle-storage-fs/test/FsStoragePlugin.test.ts
+++ b/packages/livebundle-storage-fs/test/FsStoragePlugin.test.ts
@@ -1,11 +1,11 @@
 import "mocha";
-import FsStorageImpl, { FsStorageConfig } from "../src";
+import FsStoragePlugin, { FsStorageConfig } from "../src";
 import { expect } from "chai";
 import tmp from "tmp";
 import fs from "fs-extra";
 import path from "path";
 
-describe("FsStorageImpl", () => {
+describe("FsStoragePlugin", () => {
   const storageConfig = (): FsStorageConfig => ({
     storageDir: tmp.dirSync({ unsafeCleanup: true }).name,
   });
@@ -20,22 +20,22 @@ describe("FsStorageImpl", () => {
   describe("baseUrl getter", () => {
     it("should return the root directory of the storage", () => {
       const config = storageConfig();
-      const sut = new FsStorageImpl(config);
+      const sut = new FsStoragePlugin(config);
       expect(sut.baseUrl).equal(config.storageDir);
     });
   });
 
   describe("create", () => {
-    it("should return an instance of FsStorageImpl", async () => {
-      const res = await FsStorageImpl.create(storageConfig());
-      expect(res).instanceOf(FsStorageImpl);
+    it("should return an instance of FsStoragePlugin", async () => {
+      const res = await FsStoragePlugin.create(storageConfig());
+      expect(res).instanceOf(FsStoragePlugin);
     });
   });
 
   describe("store", () => {
     it("should store the content to target file location", async () => {
       const config = storageConfig();
-      const sut = new FsStorageImpl(config);
+      const sut = new FsStoragePlugin(config);
       await sut.store("abcd", 4, "test.file");
       expect(fs.existsSync(path.join(config.storageDir!, "test.file")));
     });
@@ -45,7 +45,7 @@ describe("FsStorageImpl", () => {
     it("should store the file in target file location", async () => {
       const tmpFilePath = await writeTmpFile("foo");
       const config = storageConfig();
-      const sut = new FsStorageImpl(config);
+      const sut = new FsStoragePlugin(config);
       await sut.storeFile(tmpFilePath, "test.file");
       expect(fs.existsSync(path.join(config.storageDir!, "test.file")));
     });
@@ -54,7 +54,7 @@ describe("FsStorageImpl", () => {
   describe("hasFile", () => {
     it("should returrn true if the file exists", async () => {
       const config = storageConfig();
-      const sut = new FsStorageImpl(config);
+      const sut = new FsStoragePlugin(config);
       await fs.writeFile(path.join(config.storageDir!, "test.file"), "foo", {
         encoding: "utf-8",
       });
@@ -63,7 +63,7 @@ describe("FsStorageImpl", () => {
     });
 
     it("should returrn false if the file does not exists", async () => {
-      const sut = new FsStorageImpl(storageConfig());
+      const sut = new FsStoragePlugin(storageConfig());
       const result = await sut.hasFile("test.file");
       expect(result).false;
     });
@@ -72,7 +72,7 @@ describe("FsStorageImpl", () => {
   describe("downloadFile", () => {
     it("should return the downloaded file as a Buffer", async () => {
       const config = storageConfig();
-      const sut = new FsStorageImpl(config);
+      const sut = new FsStoragePlugin(config);
       await fs.writeFile(path.join(config.storageDir!, "test.file"), "foo", {
         encoding: "utf-8",
       });


### PR DESCRIPTION
Use `Plugin` suffix instead of `Impl` suffix.