### PR TITLE
Use Node 12 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
       - run: yarn
       - run: yarn lint
       - run: yarn build


### PR DESCRIPTION
Update GitHub workflow to use Node 12 (LTS) instead of Node 10 _(default)_