### PR TITLE
Update default config file

### DIFF
--- a/packages/livebundle/config/default.yaml
+++ b/packages/livebundle/config/default.yaml
@@ -31,8 +31,8 @@ storage:
   #
   fs:
     # Local directory for storage
-    # Leave empty to use a temporary directory
-    storageDir:
+    # No setting a path will use a temporary directory
+    storageDir: ~/.livebundle/storage
 
   # Azure blob storage provider configuration
   # We recommend using env variables here instead of


### PR DESCRIPTION
Update default `livebundle.yml` configuration file _(created with `livebundle init` command)_ to use a specific directory _(`~/.livebundle/storage`)_ instead of a temporary directory. 