### PR TITLE
Improve live command

### DIFF
--- a/packages/livebundle-sdk/src/types/index.ts
+++ b/packages/livebundle-sdk/src/types/index.ts
@@ -8,6 +8,7 @@ export interface LocalBundle {
 
 export interface LiveBundleConfig {
   bundler: Record<string, unknown>;
+  server: Record<string, unknown>;
   storage: Record<string, unknown>;
   generators: Record<string, unknown>;
   notifiers: Record<string, unknown>;
@@ -39,7 +40,7 @@ export enum LiveBundleContentType {
 
 export interface LiveBundle {
   upload(config: LiveBundleConfig): Promise<void>;
-  live(config: LiveBundleConfig): Promise<void>;
+  live(config: LiveBundleConfig, opts?: ServerOpts): Promise<void>;
 }
 
 export interface ReactNativeAsset {
@@ -52,6 +53,10 @@ export interface PluginLoader {
     name: string,
     config: Record<string, unknown>,
   ): Promise<NamedBundlerPlugin>;
+  loadServerPlugin(
+    name: string,
+    config: Record<string, unknown>,
+  ): Promise<NamedServerPlugin>;
   loadGeneratorPlugin(
     name: string,
     config: Record<string, unknown>,
@@ -69,6 +74,7 @@ export interface PluginLoader {
     config: LiveBundleConfig,
   ): Promise<{
     bundler: NamedBundlerPlugin;
+    server: NamedServerPlugin;
     storage: NamedStoragePlugin;
     generators: NamedGeneratorPlugin[];
     notifiers: NamedNotifierPlugin[];
@@ -89,6 +95,16 @@ export interface PluginClass<T> {
 
 export interface BundlerPlugin {
   bundle(): Promise<LocalBundle[]>;
+}
+
+export interface ServerPlugin {
+  launchServer(opts?: ServerOpts): Promise<void>;
+}
+
+export interface ServerOpts {
+  host?: string;
+  port?: number;
+  rest?: string[];
 }
 
 export interface GeneratorPlugin {
@@ -134,3 +150,4 @@ export type NamedBundlerPlugin = BundlerPlugin & Named;
 export type NamedStoragePlugin = StoragePlugin & Named;
 export type NamedGeneratorPlugin = GeneratorPlugin & Named;
 export type NamedNotifierPlugin = NotifierPlugin & Named;
+export type NamedServerPlugin = ServerPlugin & Named;

--- a/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
+++ b/packages/livebundle-sdk/test/LiveBundleImpl.test.ts
@@ -10,9 +10,11 @@ import {
   LocalBundle,
   PluginLoaderImpl,
   LiveBundleImpl,
+  NamedServerPlugin,
 } from "../src";
 import { v4 as uuidv4 } from "uuid";
 import sinon from "sinon";
+import { expect } from "chai";
 
 describe("LiveBundleImpl", () => {
   const sandbox = sinon.createSandbox();
@@ -30,6 +32,7 @@ describe("LiveBundleImpl", () => {
       const pluginLoaderStub = sandbox.createStubInstance(PluginLoaderImpl);
       pluginLoaderStub.loadAllPlugins.resolves({
         bundler: new FakeBundler(),
+        server: new FakeServer(),
         storage: new FakeStorage(),
         uploader: new FakeUploader(),
         generators: [new FakeGenerator()],
@@ -38,6 +41,9 @@ describe("LiveBundleImpl", () => {
       const sut = new LiveBundleImpl(pluginLoaderStub);
       await sut.upload({
         bundler: {
+          fake: null,
+        },
+        server: {
           fake: null,
         },
         generators: {
@@ -58,6 +64,7 @@ describe("LiveBundleImpl", () => {
       const pluginLoaderStub = sandbox.createStubInstance(PluginLoaderImpl);
       pluginLoaderStub.loadAllPlugins.resolves({
         bundler: new FakeBundler(),
+        server: new FakeServer(),
         storage: new FakeStorage(),
         uploader: new FakeUploader(),
         generators: [new FakeGenerator()],
@@ -66,6 +73,9 @@ describe("LiveBundleImpl", () => {
       const sut = new LiveBundleImpl(pluginLoaderStub);
       await sut.live({
         bundler: {
+          fake: null,
+        },
+        server: {
           fake: null,
         },
         generators: {
@@ -78,6 +88,17 @@ describe("LiveBundleImpl", () => {
           fake: null,
         },
       });
+    });
+  });
+
+  describe("buildLiveSessionMetadata", () => {
+    it("should return expected metadata string [host/port provided]", () => {
+      expect(
+        LiveBundleImpl.buildLiveSessionMetadata({
+          host: "1.2.3.4",
+          port: 8086,
+        }),
+      ).equals('{"host":"1.2.3.4:8086"}');
     });
   });
 });
@@ -139,6 +160,13 @@ class FakeBundler implements NamedBundlerPlugin {
   name: string;
   bundle(): Promise<LocalBundle[]> {
     return Promise.resolve([]);
+  }
+}
+
+class FakeServer implements NamedServerPlugin {
+  name: string;
+  launchServer(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/packages/livebundle-sdk/test/PluginLoaderImpl.test.ts
+++ b/packages/livebundle-sdk/test/PluginLoaderImpl.test.ts
@@ -84,6 +84,9 @@ describe("PluginLoaderImpl", () => {
         bundler: {
           metro: null,
         },
+        server: {
+          metro: null,
+        },
         storage: {
           fs: null,
         },

--- a/packages/livebundle-server-metro/.npmignore
+++ b/packages/livebundle-server-metro/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+test
+src
+tsconfig.json

--- a/packages/livebundle-server-metro/LICENSE
+++ b/packages/livebundle-server-metro/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2020 WalmartLabs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/livebundle-server-metro/README.md
+++ b/packages/livebundle-server-metro/README.md
@@ -1,0 +1,1 @@
+# LiveBundle Metro Server

--- a/packages/livebundle-server-metro/package.json
+++ b/packages/livebundle-server-metro/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "livebundle-server-metro",
+  "version": "0.3.2",
+  "main": "dist/index.js",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "yarn clean && yarn compile",
+    "clean": "rm -rf ./dist && rm -rf tsconfig.build.tsbuildinfo",
+    "compile": "tsc -b tsconfig.build.json",
+    "prepublishOnly": "yarn build",
+    "start": "node dist/index.js",
+    "test": "mocha"
+  },
+  "dependencies": {
+    "debug": "^4.2.0",
+    "fs-extra": "^9.0.1",
+    "livebundle-sdk": "^0.3.2",
+    "tmp": "^0.2.1"
+  }
+}

--- a/packages/livebundle-server-metro/src/MetroServerPlugin.ts
+++ b/packages/livebundle-server-metro/src/MetroServerPlugin.ts
@@ -1,0 +1,79 @@
+import debug from "debug";
+import { ServerPlugin, ServerOpts } from "livebundle-sdk";
+import tmp from "tmp";
+import path from "path";
+import cp from "child_process";
+import fs from "fs-extra";
+
+const log = debug("livebundle-bundler-metro:MetroServerPlugin");
+
+export class MetroServerPlugin implements ServerPlugin {
+  private readonly spawn;
+
+  public constructor({
+    spawn = cp.spawn,
+  }: {
+    spawn?: typeof cp.spawn;
+  } = {}) {
+    this.spawn = spawn;
+  }
+
+  public async launchServer(opts?: ServerOpts): Promise<void> {
+    log(`launchServer(opts:${JSON.stringify(opts, null, 2)})`);
+    return this.darwinStartPackagerInNewWindow({
+      args: this.buildCommandArgs(opts),
+    });
+  }
+
+  public static async create(): Promise<MetroServerPlugin> {
+    return new MetroServerPlugin();
+  }
+
+  public buildCommandArgs(opts?: ServerOpts): string[] {
+    const commandArgs = opts?.rest || [];
+    if (opts?.host) {
+      commandArgs.push("--host", opts.host);
+    }
+    if (opts?.port) {
+      commandArgs.push("--port", opts.port.toString(10));
+    }
+    return commandArgs;
+  }
+
+  public async darwinStartPackagerInNewWindow({
+    cwd = process.cwd(),
+    args = [],
+  }: {
+    cwd?: string;
+    args?: string[];
+  } = {}): Promise<void> {
+    const scriptPath = await this.createStartPackagerScript({
+      args,
+      cwd,
+      scriptFileName: "packager.sh",
+    });
+    this.spawn("open", ["-a", "Terminal", scriptPath]);
+  }
+
+  public async createStartPackagerScript({
+    cwd,
+    args,
+    scriptFileName,
+  }: {
+    cwd: string;
+    args: string[];
+    scriptFileName: string;
+  }): Promise<string> {
+    const tmpDir = tmp.dirSync({ unsafeCleanup: true }).name;
+    const tmpScriptPath = path.join(tmpDir, scriptFileName);
+    await fs.writeFile(
+      tmpScriptPath,
+      `cd ${cwd}
+echo "Running npx react-native start ${args.join(" ")}"
+npx react-native start ${args.join(" ")}
+`,
+    );
+    fs.chmodSync(tmpScriptPath, "777");
+    return tmpScriptPath;
+  }
+}

--- a/packages/livebundle-server-metro/src/index.ts
+++ b/packages/livebundle-server-metro/src/index.ts
@@ -1,0 +1,2 @@
+import { MetroServerPlugin } from "./MetroServerPlugin";
+export default MetroServerPlugin;

--- a/packages/livebundle-server-metro/test/MetroServerPlugin.test.ts
+++ b/packages/livebundle-server-metro/test/MetroServerPlugin.test.ts
@@ -1,0 +1,140 @@
+import "mocha";
+import MetroServerPlugin from "../src";
+import sinon from "sinon";
+import { ReactNativeAsset } from "livebundle-sdk";
+import { expect } from "chai";
+import { rejects } from "assert";
+import fs from "fs-extra";
+
+describe("MetroServerPlugin", () => {
+  const sandbox = sinon.createSandbox();
+
+  const onCloseEvent = (code: number) => (
+    e: string,
+    cb: (code: number) => void,
+  ) => {
+    if (e === "close") {
+      cb(code);
+    }
+  };
+
+  const onDataEvent = (e: string, cb: (data: string) => void) => {
+    if (e === "data") {
+      cb("foo");
+    }
+  };
+
+  const spawnRes = {
+    stdout: {
+      on: onDataEvent,
+    },
+    stderr: {
+      on: onDataEvent,
+    },
+    on: onCloseEvent(0),
+  };
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("create", () => {
+    it("should return an instance of MetroServerPlugin", async () => {
+      const res = await MetroServerPlugin.create();
+      expect(res).instanceOf(MetroServerPlugin);
+    });
+  });
+
+  describe("buildCommandArgs", () => {
+    it("should return the constructed command args [host/port provided]", () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      const args = sut.buildCommandArgs({ host: "1.2.3.4", port: 8086 });
+      expect(args).deep.equal(["--host", "1.2.3.4", "--port", "8086"]);
+    });
+
+    it("should return the constructed command args [rest provided]", () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      const args = sut.buildCommandArgs({
+        rest: ["--reset-cache", "--max-workers", "10"],
+      });
+      expect(args).deep.equal(["--reset-cache", "--max-workers", "10"]);
+    });
+
+    it("should return the constructed command args [host/port/rest provided]", () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      const args = sut.buildCommandArgs({
+        host: "1.2.3.4",
+        port: 8086,
+        rest: ["--reset-cache", "--max-workers", "10"],
+      });
+      expect(args).deep.equal([
+        "--reset-cache",
+        "--max-workers",
+        "10",
+        "--host",
+        "1.2.3.4",
+        "--port",
+        "8086",
+      ]);
+    });
+  });
+
+  describe("createPackagerScript", () => {
+    it("should write the correct script content", async () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      const scriptPath = await sut.createStartPackagerScript({
+        cwd: process.cwd(),
+        args: ["--port", "8086", "--reset-cache"],
+        scriptFileName: "packager.sh",
+      });
+      const scriptContent = await fs.readFile(scriptPath, "utf-8");
+      expect(scriptContent).equal(`cd ${process.cwd()}
+echo "Running npx react-native start --port 8086 --reset-cache"
+npx react-native start --port 8086 --reset-cache
+`);
+    });
+  });
+
+  describe("darwinStartPackagerInNewWindow", () => {
+    it("should go through", async () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      await sut.darwinStartPackagerInNewWindow();
+    });
+  });
+
+  describe("launchServer", () => {
+    it("should go through", async () => {
+      const spawn = sandbox.stub().returns(spawnRes);
+      const sut = new MetroServerPlugin({ spawn });
+      await sut.launchServer();
+    });
+  })
+
+  // describe("bundle", () => {
+
+  //   it("should go through", async () => {
+  //     const spawn = sandbox.stub().returns(spawnRes);
+  //     const sut = new MetroBundlerPlugin(bundlerConfig, {
+  //       bundleAssetsResolver: new NullBundleAssetsResolver(),
+  //       spawn,
+  //     });
+  //     await sut.bundle();
+  //   });
+
+  //   it("should throw if react-native bundle command exits with a non 0 exit code", async () => {
+  //     const spawn = sandbox
+  //       .stub()
+  //       .returns({ ...spawnRes, on: onCloseEvent(1) });
+  //     const sut = new MetroBundlerPlugin(bundlerConfig, {
+  //       bundleAssetsResolver: new NullBundleAssetsResolver(),
+  //       spawn,
+  //     });
+  //     await rejects(sut.bundle());
+  //   });
+  // });
+});

--- a/packages/livebundle-server-metro/tsconfig.build.json
+++ b/packages/livebundle-server-metro/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "typeRoots": ["./typings"],
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "references": [
+    {
+      "path": "../livebundle-sdk/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/livebundle/config/default.yaml
+++ b/packages/livebundle/config/default.yaml
@@ -8,6 +8,7 @@
 #
 # JavaScript bundler configuration
 # Only one bundler can be specified
+# Only used for 'upload' command
 bundler:
   # Metro bundler configuration
   #
@@ -20,6 +21,13 @@ bundler:
       - dev: true
         entry: index.js
         platform: ios
+
+# React Native server configuration
+# Only used for 'live' command
+server:
+  # Metro  server configuration
+  #
+  metro:
 
 #
 # Storage provider configuration

--- a/packages/livebundle/package.json
+++ b/packages/livebundle/package.json
@@ -26,6 +26,7 @@
     "livebundle-notifier-terminal": "^0.3.2",
     "livebundle-notifier-viewer": "^0.3.2",
     "livebundle-sdk": "^0.3.2",
+    "livebundle-server-metro": "^0.3.2",
     "livebundle-storage-azure": "^0.3.2",
     "livebundle-storage-fs": "^0.3.2",
     "lodash": "^4.17.20",

--- a/packages/livebundle/src/schemas/config.json
+++ b/packages/livebundle/src/schemas/config.json
@@ -5,6 +5,9 @@
     "bundler": {
       "type": "object"
     },
+    "server": {
+      "type": "object"
+    },
     "storage": {
       "type": "object"
     },
@@ -15,5 +18,5 @@
       "type": "object"
     }
   },
-  "required": [ "bundler", "storage", "generators", "notifiers" ]
+  "required": [ "bundler", "server", "storage", "generators", "notifiers" ]
 }


### PR DESCRIPTION
Improve `live` command so that it now starts the bundler server.
To remain modular so that this command can be used with different bundlers, this PR also introduces a new `Server` plugin category. First implementation shipped in this PR is `livebundle-server-metro` plugin that can launch a metro server.
The `live` command now accepts `host` and `port` options. By default the `host` will be set to the local IP address of the machine, and the port will be set to `8081`. These options (host/port) are passed through and provided to `npx react-native start` command along with any other options supported by this command.