### PR TITLE
Add host to DeepLink generator config

### DIFF
--- a/packages/livebundle-generator-deeplink/config/default.json
+++ b/packages/livebundle-generator-deeplink/config/default.json
@@ -1,0 +1,3 @@
+{
+  "host": "io.livebundle"
+}

--- a/packages/livebundle-generator-deeplink/config/default.yaml
+++ b/packages/livebundle-generator-deeplink/config/default.yaml
@@ -1,0 +1,1 @@
+host: io.livebundle

--- a/packages/livebundle-generator-deeplink/src/DeepLinkGeneratorPlugin.ts
+++ b/packages/livebundle-generator-deeplink/src/DeepLinkGeneratorPlugin.ts
@@ -1,13 +1,25 @@
 import debug from "debug";
-import { DeepLinkGeneratorResult } from "./types";
+import { DeepLinkGeneratorResult, DeepLinkGeneratorConfig } from "./types";
 import { LiveBundleContentType, GeneratorPlugin } from "livebundle-sdk";
+import { configSchema } from "./schemas";
 
 const log = debug("livebundle-generator-deeplink:DeepLinkGeneratorPlugin");
 
 export class DeepLinkGeneratorPlugin implements GeneratorPlugin {
-  public static async create(): Promise<DeepLinkGeneratorPlugin> {
-    return new DeepLinkGeneratorPlugin();
+  public constructor(private readonly config: DeepLinkGeneratorConfig) {}
+
+  public static async create(
+    config: DeepLinkGeneratorConfig,
+  ): Promise<DeepLinkGeneratorPlugin> {
+    return new DeepLinkGeneratorPlugin(config);
   }
+
+  public static readonly defaultConfig: Record<
+    string,
+    unknown
+  > = require("../config/default.json");
+
+  public static readonly schema: Record<string, unknown> = configSchema;
 
   async generate({
     id,
@@ -18,7 +30,7 @@ export class DeepLinkGeneratorPlugin implements GeneratorPlugin {
   }): Promise<DeepLinkGeneratorResult> {
     log(`generate(id: ${id}, type: ${type})`);
     return type === LiveBundleContentType.PACKAGE
-      ? { deepLinkUrl: `livebundle://packages?id=${id}` }
-      : { deepLinkUrl: `livebundle://sessions?id=${id}` };
+      ? { deepLinkUrl: `livebundle://${this.config.host}/packages?id=${id}` }
+      : { deepLinkUrl: `livebundle://${this.config.host}/sessions?id=${id}` };
   }
 }

--- a/packages/livebundle-generator-deeplink/src/schemas/config.json
+++ b/packages/livebundle-generator-deeplink/src/schemas/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://electrode.io/schemas/generator-deeplink.json",
+  "type": "object",
+  "properties": {
+    "host": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/livebundle-generator-deeplink/src/schemas/index.ts
+++ b/packages/livebundle-generator-deeplink/src/schemas/index.ts
@@ -1,0 +1,2 @@
+import configSchema from "./config.json";
+export { configSchema };

--- a/packages/livebundle-generator-deeplink/src/types/index.ts
+++ b/packages/livebundle-generator-deeplink/src/types/index.ts
@@ -1,3 +1,6 @@
 export interface DeepLinkGeneratorResult extends Record<string, unknown> {
   deepLinkUrl: string;
 }
+export interface DeepLinkGeneratorConfig extends Record<string, unknown> {
+  host: string;
+}

--- a/packages/livebundle-generator-deeplink/test/DeepLinkGeneratorPlugin.test.ts
+++ b/packages/livebundle-generator-deeplink/test/DeepLinkGeneratorPlugin.test.ts
@@ -7,30 +7,30 @@ import { LiveBundleContentType } from "livebundle-sdk";
 describe("DeepLinkGeneratorPlugin", () => {
   describe("create", () => {
     it("should return an instance of DeepLinkGeneratorPlugin", async () => {
-      const res = await DeepLinkGeneratorPlugin.create();
+      const res = await DeepLinkGeneratorPlugin.create({host: "io.livebundle"});
       expect(res).instanceOf(DeepLinkGeneratorPlugin);
     });
   });
 
   describe("generate", () => {
     it("should generate a LiveBundle package DeepLink", async () => {
-      const sut = new DeepLinkGeneratorPlugin();
+      const sut = new DeepLinkGeneratorPlugin({host: "io.livebundle"});
       const id = uuidv4();
       const result = await sut.generate({
         id,
         type: LiveBundleContentType.PACKAGE,
       });
-      expect(result.deepLinkUrl).eql(`livebundle://packages?id=${id}`);
+      expect(result.deepLinkUrl).eql(`livebundle://io.livebundle/packages?id=${id}`);
     });
 
     it("should generate a LiveBundle session DeepLink", async () => {
-      const sut = new DeepLinkGeneratorPlugin();
+      const sut = new DeepLinkGeneratorPlugin({host: "io.livebundle"});
       const id = uuidv4();
       const result = await sut.generate({
         id,
         type: LiveBundleContentType.SESSION,
       });
-      expect(result.deepLinkUrl).eql(`livebundle://sessions?id=${id}`);
+      expect(result.deepLinkUrl).eql(`livebundle://io.livebundle/sessions?id=${id}`);
     });
   });
 });

--- a/packages/livebundle/config/default.yaml
+++ b/packages/livebundle/config/default.yaml
@@ -73,6 +73,8 @@ generators:
   # Deep Link generator configuration
   #
   deeplink:
+    # Replace this value with your application reverse domain
+    host: io.livebundle
 
 #
 # Notifiers configuration


### PR DESCRIPTION
For example, instead of `livebundle://menu` menu deep link url, the url is now `livebundle://io.livebundle.example/menu` for the example LiveBundle application. This avoid having Android to show a picker for the application in which to open the deep link intent in case multiple applications running LiveBundle are installed on the device.

Corresponding PR in native module : https://github.com/electrode-io/react-native-livebundle/pull/55