### PR TITLE
Disable ajv strict mode

### DIFF
--- a/packages/livebundle-sdk/src/schemaValidate.ts
+++ b/packages/livebundle-sdk/src/schemaValidate.ts
@@ -16,7 +16,7 @@ export function schemaValidate<T>({
 refSchemas: ${refSchemas.map((s) => s["$id"])}
 schema: ${schema["$id"]}}`);
 
-  const ajv = new Ajv({ $data: true });
+  const ajv = new Ajv({ $data: true, strict: false });
   for (const refSchema of refSchemas) {
     ajv.addSchema(refSchema);
   }


### PR DESCRIPTION
To avoid warnings being logged due to the use of `draft-07` schema version _(https://github.com/ajv-validator/ajv/issues/1373)_