### PR TITLE
Fix QRCodeGenerator plugin default directory

### DIFF
--- a/packages/livebundle-generator-qrcode/package.json
+++ b/packages/livebundle-generator-qrcode/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "debug": "^4.3.1",
+    "fs-extra": "^10.0.0",
     "livebundle-sdk": "^0.3.5",
     "qrcode": "^1.4.4"
   }

--- a/packages/livebundle-generator-qrcode/src/QRCodeGeneratorPlugin.ts
+++ b/packages/livebundle-generator-qrcode/src/QRCodeGeneratorPlugin.ts
@@ -1,10 +1,11 @@
-import debug from "debug";
 import { QrCodeGeneratorConfig, QrCodeGeneratorResult } from "./types";
 import {
   LiveBundleContentType,
   StoragePlugin,
   GeneratorPlugin,
 } from "livebundle-sdk";
+import debug from "debug";
+import fs from "fs-extra";
 import { configSchema } from "./schemas";
 import path from "path";
 import qrcode from "qrcode";
@@ -44,6 +45,7 @@ export class QRCodeGeneratorPlugin implements GeneratorPlugin {
 
     //
     // Generate as local png image file
+    await fs.ensureDir(path.dirname(this.config.image.path));
     const localImagePath = path.resolve(this.config.image.path);
     await qrcode.toFile(localImagePath, pkgId, {
       margin: this.config.image.margin,


### PR DESCRIPTION
QRCode image is generated in `.livebundle/qrcode.png` path.
It fails out of the box when running `livebundle upload` because the `.livebundle` directory does not exist in application root. 
Add guard to make sure the directory exists, creating it if necessary.