### PR TITLE
Fix FsStorage plugin directory guard

### DIFF
--- a/packages/livebundle-storage-fs/src/FsStoragePlugin.ts
+++ b/packages/livebundle-storage-fs/src/FsStoragePlugin.ts
@@ -30,7 +30,7 @@ export class FsStoragePlugin implements StoragePlugin {
     this.storageDir = fsConfig.storageDir
       ? untildifyPath(fsConfig.storageDir)
       : tmp.dirSync({ unsafeCleanup: true }).name;
-    fs.ensureDir(this.storageDir);
+    fs.ensureDirSync(this.storageDir);
   }
 
   hasFile(filePath: string): Promise<boolean> {


### PR DESCRIPTION
Update call to `ensureDir` to use the synchronous version, given that we are in a synchronous function _(constructor)_